### PR TITLE
Change Nakadi environment variable for test suite to TEST_NAKADI_ENDP…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ after_script:
 
 script:
 # Build the package, its tests, and its docs and run the tests
-- NAKADI_ENDPOINT=http://localhost:8080/ stack --no-terminal test --haddock --no-haddock-deps
+- TEST_NAKADI_ENDPOINT=http://localhost:8080/ stack --no-terminal test --haddock --no-haddock-deps

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -11,8 +11,8 @@ import           Test.Tasty
 
 createConfig :: IO Config
 createConfig = do
-  nakadiEndpoint <- fromMaybe (error "NAKADI_ENDPOINT not set") <$>
-                    lookupEnv "NAKADI_ENDPOINT"
+  nakadiEndpoint <- fromMaybe (error "TEST_NAKADI_ENDPOINT not set") <$>
+                    lookupEnv "TEST_NAKADI_ENDPOINT"
   request <- parseRequest nakadiEndpoint
   newConfig Nothing request
 


### PR DESCRIPTION
…OINT to ensure that it is never confused with a production Nakadi. Also, preserve Conduit batching during listing of subscriptions.