### PR TITLE
Use EventEnriched in EventStreamBatch

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
-version: '0.3.0.1'
+version: '0.3.1.0'
 synopsis: Client library for the Nakadi Event Broker
 description: This package implements a client library for interacting
              with the Nakadi event broker system developed by Zalando.

--- a/src/Network/Nakadi/Internal/Types/Service.hs
+++ b/src/Network/Nakadi/Internal/Types/Service.hs
@@ -242,24 +242,6 @@ data Event a = Event
 
 deriveJSON nakadiJsonOptions ''Event
 
--- | EventStreamBatch
-
-data EventStreamBatch a = EventStreamBatch
-  { _cursor :: Cursor -- ^ Cursor for this batch
-  , _events :: Maybe (Vector (Event a)) -- ^ Events in this batch
-  } deriving (Show, Generic)
-
-deriveJSON nakadiJsonOptions ''EventStreamBatch
-
--- | SubscriptionEventStreamBatch
-
-data SubscriptionEventStreamBatch a = SubscriptionEventStreamBatch
-  { _cursor :: SubscriptionCursor -- ^ cursor for this subscription batch
-  , _events :: Maybe (Vector (Event a)) -- ^ Events for this subscription batch
-  } deriving (Show, Generic)
-
-deriveJSON nakadiJsonOptions ''SubscriptionEventStreamBatch
-
 -- | ID of an Event
 
 newtype EventId = EventId
@@ -759,6 +741,23 @@ deriveJSON nakadiJsonOptions {
                                         , ("_metadata", "metadata") ]
   }  ''EventEnriched
 
+-- | EventStreamBatch
+
+data EventStreamBatch a = EventStreamBatch
+  { _cursor :: Cursor -- ^ Cursor for this batch
+  , _events :: Maybe (Vector (EventEnriched a)) -- ^ Events in this batch
+  } deriving (Show, Generic)
+
+deriveJSON nakadiJsonOptions ''EventStreamBatch
+
+-- | SubscriptionEventStreamBatch
+
+data SubscriptionEventStreamBatch a = SubscriptionEventStreamBatch
+  { _cursor :: SubscriptionCursor -- ^ cursor for this subscription batch
+  , _events :: Maybe (Vector (EventEnriched a)) -- ^ Events for this subscription batch
+  } deriving (Show, Generic)
+
+deriveJSON nakadiJsonOptions ''SubscriptionEventStreamBatch
 
 -- | Type for "data_op" as contained in the DataChangeEvent.
 


### PR DESCRIPTION
Use EventEnriched (including MetadataEnriched instead of plain Metadata) for event consumption.

When publishing events one uses the Metadata type, when consuming events one should use MetadataEnriched, right? This is after Nakadi has enriched the event's metadata.