### PR TITLE
 Pluggable http backends

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
-version: '0.3.0.1'
+version: '0.3.1.0'
 synopsis: Client library for the Nakadi Event Broker
 description: This package implements a client library for interacting
              with the Nakadi event broker system developed by Zalando.

--- a/src/Network/Nakadi/Internal/Lenses.hs
+++ b/src/Network/Nakadi/Internal/Lenses.hs
@@ -37,6 +37,7 @@ class HasNakadiConfig s a where
   nakadiConfig :: Lens' s a
 
 makeNakadiLenses ''Config
+makeNakadiLenses ''HttpBackend
 makeNakadiLenses ''Cursor
 makeNakadiLenses ''EventStreamBatch
 makeNakadiLenses ''SubscriptionEventStreamBatch

--- a/src/Network/Nakadi/Internal/Types/Config.hs
+++ b/src/Network/Nakadi/Internal/Types/Config.hs
@@ -17,6 +17,7 @@ import           Network.Nakadi.Internal.Prelude
 import           Control.Retry
 import           Network.HTTP.Client
 
+import qualified Data.ByteString.Lazy as LB (ByteString)
 import           Network.Nakadi.Types.Logger
 
 -- | Config
@@ -32,6 +33,13 @@ data Config = Config
   , _streamConnectCallback          :: Maybe StreamConnectCallback
   , _logFunc                        :: Maybe LogFunc
   , _retryPolicy                    :: RetryPolicyM IO
+  , _http                           :: HttpBackend
+  }
+
+data HttpBackend = HttpBackend
+  { _httpLbs                        :: Request -> IO (Response LB.ByteString)
+  , _responseOpen                   :: Request -> Manager -> IO (Response BodyReader)
+  , _responseClose                  :: Response BodyReader -> IO ()
   }
 
 -- | ConsumeParameters

--- a/src/Network/Nakadi/Types/Config.hs
+++ b/src/Network/Nakadi/Types/Config.hs
@@ -12,6 +12,7 @@ This module provides the Nakadi Config Types.
 
 module Network.Nakadi.Types.Config
   ( Config
+  , HttpBackend(..)
   , ConsumeParameters
   , StreamConnectCallback
   ) where

--- a/tests/Network/Nakadi/Config/Test.hs
+++ b/tests/Network/Nakadi/Config/Test.hs
@@ -1,0 +1,48 @@
+module Network.Nakadi.Config.Test where
+
+import           ClassyPrelude
+import           Control.Lens         ((<&>))
+import           Control.Retry
+import qualified Data.ByteString.Lazy as LB
+import           Network.HTTP.Client
+import           Network.Nakadi
+import           System.IO.Unsafe
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+testConfig :: TestTree
+testConfig = testGroup "Config"
+  [ testCase "Use Custom HttpBackend" testCustomHttpBackend ]
+
+{-# NOINLINE requestsExecuted #-}
+requestsExecuted :: TVar [Request]
+requestsExecuted = unsafePerformIO . newTVarIO $ []
+
+dummyHttpLbs :: Request -> IO (Response LB.ByteString)
+dummyHttpLbs req = do
+  atomically $ modifyTVar requestsExecuted (req :)
+  throwIO (HttpExceptionRequest req ResponseTimeout)
+
+dummyResponseOpen :: Request -> Manager -> IO (Response (IO ByteString))
+dummyResponseOpen req _manager = do
+  atomically $ modifyTVar requestsExecuted (req :)
+  throwIO (HttpExceptionRequest req ResponseTimeout)
+
+dummyResponseClose :: Response BodyReader -> IO ()
+dummyResponseClose _response = return ()
+
+dummyHttpBackend :: HttpBackend
+dummyHttpBackend = HttpBackend dummyHttpLbs dummyResponseOpen dummyResponseClose
+
+testCustomHttpBackend :: Assertion
+testCustomHttpBackend = do
+  let trivialRetryPolicy = limitRetries 0
+  conf <- newConfig Nothing defaultRequest
+          <&> setHttpBackend dummyHttpBackend
+          <&> setRetryPolicy trivialRetryPolicy
+  res0 <- try $ registryPartitionStrategies conf -- This should use httpLbs
+  case res0 of
+    Left (HttpExceptionRequest _ ResponseTimeout) -> return ()
+    _ -> assertFailure "Expected ResponseTimeout exception from dummy HttpBackend"
+  requests <- atomically . readTVar $ requestsExecuted
+  1 @=? length requests

--- a/tests/Network/Nakadi/Connection/Test.hs
+++ b/tests/Network/Nakadi/Connection/Test.hs
@@ -1,18 +1,17 @@
 module Network.Nakadi.Connection.Test where
 
-import ClassyPrelude
-import Network.Wai.Handler.Warp
-import qualified Network.Wai as Wai
-import Network.HTTP.Types
-import Network.HTTP.Client ( Request(..)
-                           , HttpException(..)
-                           , HttpExceptionContent(..)
-                           , responseTimeoutMicro
-                           , parseRequest)
+import           ClassyPrelude
+import           Network.HTTP.Client      (HttpException (..),
+                                           HttpExceptionContent (..),
+                                           Request (..), parseRequest,
+                                           responseTimeoutMicro)
+import           Network.HTTP.Types
 import           Network.Nakadi
+import qualified Network.Wai              as Wai
+import           Network.Wai.Handler.Warp
+import           System.IO.Unsafe
 import           Test.Tasty
 import           Test.Tasty.HUnit
-import System.IO.Unsafe
 
 testConnection :: TestTree
 testConnection = testGroup "Connection.Retry"

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -2,6 +2,7 @@ import           ClassyPrelude
 
 import           Network.HTTP.Client
 import           Network.Nakadi
+import           Network.Nakadi.Config.Test
 import           Network.Nakadi.Connection.Test
 import           Network.Nakadi.EventTypes.Test
 import           Network.Nakadi.Registry.Test
@@ -23,7 +24,8 @@ main = do
 
 tests :: Config -> TestTree
 tests conf = testGroup "Test Suite"
-  [ testConnection
+  [ testConfig
+  , testConnection
   , testEventTypes conf
   , testRegistry conf
   , testSubscriptions conf


### PR DESCRIPTION
This is for easier testing.

Especially the bug about not calling the request modifier on streaming can easily be turned into a test case when the Http Backend can be replaced with a dummy.

@etorreborre @vitold, maybe you would like to have a look at this.