### PR TITLE
Fixed the deserialization of cursor commit results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ cabal.sandbox.config
 cabal.project.local
 TAGS
 nakadi-client.cabal
+.idea
+out
+*.iml

--- a/package.yaml
+++ b/package.yaml
@@ -1,3 +1,4 @@
+name: nakadi-client
 version: '0.3.1.0'
 synopsis: Client library for the Nakadi Event Broker
 description: This package implements a client library for interacting

--- a/src/Network/Nakadi/Internal/Types/Exceptions.hs
+++ b/src/Network/Nakadi/Internal/Types/Exceptions.hs
@@ -31,7 +31,7 @@ data NakadiException = BatchPartiallySubmitted [BatchItemResponse]
                      | TooManyRequests Problem
                      | BadRequest Problem
                      | SubscriptionNotFound Problem
-                     | CursorAlreadyCommitted [CursorCommitResult]
+                     | CursorAlreadyCommitted CursorCommitResults
                      | CursorResetInProgress Problem
                      | EventTypeNotFound Problem
                      | SubscriptionExistsAlready Subscription

--- a/src/Network/Nakadi/Internal/Types/Service.hs
+++ b/src/Network/Nakadi/Internal/Types/Service.hs
@@ -435,6 +435,12 @@ data CursorCommitResult = CursorCommitResult
 
 deriveJSON nakadiJsonOptions ''CursorCommitResult
 
+newtype CursorCommitResults = CursorCommitResults
+  { _items :: [CursorCommitResult]
+  } deriving (Show, Eq, Ord)
+
+deriveJSON nakadiJsonOptions ''CursorCommitResults
+
 -- | SchemaType
 
 data SchemaType = SchemaTypeJson

--- a/src/Network/Nakadi/Types/Service.hs
+++ b/src/Network/Nakadi/Types/Service.hs
@@ -45,6 +45,7 @@ module Network.Nakadi.Types.Service
   , BatchFlushTimeout(..)
   , CursorCommitResultType(..)
   , CursorCommitResult(..)
+  , CursorCommitResults(..)
   , SchemaType(..)
   , EventTypeSchema(..)
   , PaginationLink(..)

--- a/tests/Network/Nakadi/Internal/Test.hs
+++ b/tests/Network/Nakadi/Internal/Test.hs
@@ -1,0 +1,9 @@
+module Network.Nakadi.Internal.Test where
+
+import Test.Tasty
+import Network.Nakadi.Internal.Types.Test
+
+testInternal :: TestTree
+testInternal = testGroup "Internal"
+  [ testTypes
+  ]

--- a/tests/Network/Nakadi/Internal/Types/Test.hs
+++ b/tests/Network/Nakadi/Internal/Types/Test.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings     #-}
+
+module Network.Nakadi.Internal.Types.Test where
+
+import ClassyPrelude
+import Test.Tasty
+import Test.Tasty.HUnit
+import Data.Aeson
+import Network.Nakadi.Types.Service
+
+testTypes :: TestTree
+testTypes = testGroup "Types"
+  [ testService
+  ]
+
+testService :: TestTree
+testService = testGroup "Service"
+  [ testCase "JSON-decoding CursorCommitResults" testDecodeCursorCommitResults
+  ]
+
+testDecodeCursorCommitResults :: Assertion
+testDecodeCursorCommitResults = assertBool "Failed to decode" $ isJust (decode sampleResponse :: (Maybe CursorCommitResults))
+  where sampleResponse = "{\"items\":[{\"cursor\":{\"partition\":\"0\",\"offset\":\"001-0001-000000000000007598\",\"event_type\":\"http4s-nakadi.test-event\",\"cursor_token\":\"3bb3a590-ede5-43a9-981e-2bea26347c99\"},\"result\":\"outdated\"}]}"

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -11,6 +11,7 @@ import           System.Environment
 import           System.Exit
 import           System.IO                         (hFlush)
 import           Test.Tasty
+import           Network.Nakadi.Internal.Test
 
 main :: IO ()
 main = do
@@ -60,6 +61,7 @@ unitTests :: [TestTree]
 unitTests =
   [ testConfig
   , testConnection
+  , testInternal
   ]
 
 integrationTests :: Config -> [TestTree]


### PR DESCRIPTION
Fixed the deserialization of the `200 OK` response to `POST  /subscriptions/{subscription_id}/cursors`.