### PR TITLE
Implement devel flag cabal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ after_script:
 - (cd $HOME/nakadi; TERM=dumb ./gradlew stopNakadi)
 
 script:
-- TEST_NAKADI_ENDPOINT=http://localhost:8080/ stack --no-terminal test
+- TEST_NAKADI_ENDPOINT=http://localhost:8080/ stack --no-terminal test --flag nakadi-client:devel

--- a/package.yaml
+++ b/package.yaml
@@ -15,10 +15,21 @@ default-extensions:
 - NoImplicitPrelude
 - OverloadedStrings
 - DuplicateRecordFields
-ghc-options:
-- -Wall
-- -fno-warn-type-defaults
-- -Werror
+flags:
+  devel:
+    manual: true
+    default: false
+when:
+- condition: flag(devel)
+  then:
+    ghc-options:
+    - -Wall
+    - -fno-warn-type-defaults
+    - -Werror
+  else:
+    ghc-options:
+    - -Wall
+    - -fno-warn-type-defaults
 dependencies:
 - base >=4.7 && <5
 - conduit


### PR DESCRIPTION
Hackage doesn't seem to accept packages which have -Werror set unconditionally.
This implements a flag 'devel' for the nakad-client package, which activates -Werror.
