### PR TITLE
Bring back HasNakadiConfig using Functional Dependencies and simplify MonadNakadi typeclass

### DIFF
--- a/src/Network/Nakadi.hs
+++ b/src/Network/Nakadi.hs
@@ -24,7 +24,6 @@ import           Network.Nakadi.Base
 import           Network.Nakadi.Config
 import           Network.Nakadi.EventTypes
 import           Network.Nakadi.HttpBackendIO
-import           Network.Nakadi.Internal.Lenses
 import           Network.Nakadi.Registry
 import           Network.Nakadi.Subscriptions
 import           Network.Nakadi.Types

--- a/src/Network/Nakadi/Internal/Lenses.hs
+++ b/src/Network/Nakadi/Internal/Lenses.hs
@@ -32,9 +32,6 @@ import           Network.Nakadi.Internal.TH
 import           Network.Nakadi.Internal.Types.Config
 import           Network.Nakadi.Internal.Types.Service
 
-class HasNakadiConfig s a where
-  nakadiConfig :: Lens' s a
-
 makeNakadiLenses ''Config
 makeNakadiLenses ''HttpBackend
 makeNakadiLenses ''Cursor

--- a/src/Network/Nakadi/Types.hs
+++ b/src/Network/Nakadi/Types.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Network.Nakadi.Types
 Description : Nakadi API Types
-Copyright   : (c) Moritz Schulte 2017, 2018
+Copyright   : (c) Moritz Clasmeier 2017, 2018
 License     : BSD3
 Maintainer  : mtesseract@silverratio.net
 Stability   : experimental
@@ -25,7 +25,6 @@ module Network.Nakadi.Types
 
 import           Network.Nakadi.Internal.Types
 
-import           Network.Nakadi.Internal.Lenses
 import           Network.Nakadi.Types.Config
 import           Network.Nakadi.Types.Exceptions
 import           Network.Nakadi.Types.Logger

--- a/tests/Network/Nakadi/MonadicAPI/Test.hs
+++ b/tests/Network/Nakadi/MonadicAPI/Test.hs
@@ -1,10 +1,14 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
 
 module Network.Nakadi.MonadicAPI.Test where
 
 import           ClassyPrelude
 import           Control.Lens
 import           Control.Monad.Logger
+import           Control.Monad.State.Strict
 import           Control.Monad.Trans.Resource
 import           Control.Retry
 import           Network.HTTP.Client
@@ -24,6 +28,7 @@ testMonadicAPI conf = testGroup "Monadic API"
   [ testCase "Simple Monadic API" (testSimpleMonadicAPI conf')
   , testCase "Simple NakadiBaseT" (testSimpleNakadiBaseT confLifted)
   , testCase "NakadiBaseT with non-trivial stack" (testNonTrivNakadiBaseT confLifted)
+  , testCase "MonadNakadi instance for ReaderT" (testReaderT conf)
   ]
 
   where conf' = Nakadi.setHttpErrorCallback httpErrorCallback conf
@@ -34,7 +39,7 @@ testSimpleMonadicAPI conf = runApp . Nakadi.runNakadiT conf $ do
   -- Tests Nakadi call within NakadiT monad transformer
   _events <- Nakadi.eventTypesList
   -- But we can also call Nakadi from within monad transformers on top of NakadiT:
-  flip runReaderT () $ do
+  void $ flip runStateT () $ do
     _events <- Nakadi.eventTypesList
     pure ()
   -- Required for consuming via subscription API is the ability to
@@ -57,5 +62,18 @@ testSimpleNakadiBaseT conf = runApp . Nakadi.runNakadiWithBase conf $ do
 testNonTrivNakadiBaseT :: Nakadi.Config (NakadiBaseT App) -> Assertion
 testNonTrivNakadiBaseT conf =
   runApp . Nakadi.runNakadiBaseT . runNoLoggingT . Nakadi.runNakadiT conf $ do
+  _events <- Nakadi.eventTypesList
+  pure ()
+
+
+data Env = Env { nakadiConfiguration :: Nakadi.Config App }
+
+instance Nakadi.HasNakadiConfig App Env where
+  nakadiConfig = nakadiConfiguration
+
+-- | This test uses the 'MonadNakadi' instance for 'ReaderT' with a
+-- 'HasNakadiConfig' constraint.
+testReaderT :: Nakadi.Config App -> Assertion
+testReaderT conf = runApp . flip runReaderT (Env conf) $ do
   _events <- Nakadi.eventTypesList
   pure ()


### PR DESCRIPTION
#73 

Define HasNakadiConfig typeclass using simplified interface and using functional dependencies.

Simplify MonadNakadi typeclass significantly. What nakadi-client itself only needs is a way to obtain the Nakadi configuration.
The other functionality that was inspired by ReaderT is not required within the library itself.

If a user needs this functionality (e.g., local), ReaderT together with the standard functions can be used.

Add test, which uses the MonadNakadi instance for ReaderT.