### PR TITLE
Changed behaviour on deserialization failure

### DIFF
--- a/src/Network/Nakadi/Internal/Types/Exceptions.hs
+++ b/src/Network/Nakadi/Internal/Types/Exceptions.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Network.Nakadi.Internal.Types.Exceptions
 Description : Nakadi Client Exceptions (Internal)
-Copyright   : (c) Moritz Schulte 2017, 2018
+Copyright   : (c) Moritz Clasmeier 2017, 2018
 License     : BSD3
 Maintainer  : mtesseract@silverratio.net
 Stability   : experimental
@@ -16,7 +16,6 @@ module Network.Nakadi.Internal.Types.Exceptions where
 
 import           Network.Nakadi.Internal.Prelude
 
-import qualified Data.ByteString.Lazy            as ByteString.Lazy
 import           Network.Nakadi.Types.Problem
 import           Network.Nakadi.Types.Service
 
@@ -27,7 +26,7 @@ data NakadiException = BatchPartiallySubmitted [BatchItemResponse]
                      | AccessForbidden Problem
                      | UnprocessableEntity Problem
                      | Conflict Problem
-                     | DeserializationFailure ByteString.Lazy.ByteString
+                     | DeserializationFailure ByteString Text
                      | UnexpectedResponse (Response ())
                      | NotFound Problem
                      | TooManyRequests Problem

--- a/src/Network/Nakadi/Internal/Util.hs
+++ b/src/Network/Nakadi/Internal/Util.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Network.Nakadi.Internal.Util
 Description : Nakadi Client Utilities (Internal)
-Copyright   : (c) Moritz Schulte 2017, 2018
+Copyright   : (c) Moritz Clasmeier 2017, 2018
 License     : BSD3
 Maintainer  : mtesseract@silverratio.net
 Stability   : experimental
@@ -27,6 +27,7 @@ import           Data.ByteString.Builder
 import qualified Data.ByteString.Lazy            as ByteString.Lazy
 import           Data.Conduit
 import           Data.Conduit.Combinators        hiding (decodeUtf8, map)
+import qualified Data.Text                       as Text
 import           Network.HTTP.Simple
 
 import           Network.Nakadi.Internal.Types
@@ -38,10 +39,13 @@ conduitDrainToLazyByteString ::
 conduitDrainToLazyByteString conduit =
   toLazyByteString <$> (conduit $$ sinkBuilder)
 
-decodeThrow :: (FromJSON a, MonadThrow m) => ByteString.Lazy.ByteString -> m a
-decodeThrow s = case decode s of
-  Just a  -> return a
-  Nothing -> throwIO (DeserializationFailure s)
+decodeThrow
+  :: (FromJSON a, MonadThrow m)
+  => ByteString.Lazy.ByteString
+  -> m a
+decodeThrow s = case eitherDecode' s of
+  Right a  -> pure a
+  Left err -> throwM (DeserializationFailure (ByteString.Lazy.toStrict s) (Text.pack err))
 
 sequenceSnd :: Functor f => (a, f b) -> f (a, b)
 sequenceSnd (a, fb) = (a,) <$> fb

--- a/tests/Network/Nakadi/EventTypes/Test.hs
+++ b/tests/Network/Nakadi/EventTypes/Test.hs
@@ -123,7 +123,7 @@ testEventTypePublishData conf = runApp . runNakadiT conf $ do
                               }
   withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
     liftIO $ link asyncHandle
-    eventConsumed :: Maybe (EventStreamBatch Foo) <-
+    eventConsumed :: Maybe (EventStreamBatch (DataChangeEvent Foo)) <-
       eventsProcessConduit (Just consumeParametersSingle) myEventTypeName Nothing headC
     liftIO $ isJust eventConsumed @=? True
 

--- a/tests/Network/Nakadi/EventTypes/Test.hs
+++ b/tests/Network/Nakadi/EventTypes/Test.hs
@@ -35,6 +35,7 @@ testEventTypes conf = testGroup "EventTypes"
   , testCase "EventTypeCursorDistances10" (testEventTypeCursorDistances10 conf)
   , testCase "EventTypePublishData" (testEventTypePublishData conf)
   , testCase "EventTypeParseFlowId" (testEventTypeParseFlowId conf)
+  , testCase "EventTypeDeserializationFailureException" (testEventTypeDeserializationFailureException conf)
   , testCase "EventTypeDeserializationFailure" (testEventTypeDeserializationFailure conf)
   , testEventTypesShiftedCursors conf
   , testEventTypesCursorsLag conf
@@ -123,9 +124,9 @@ testEventTypePublishData conf = runApp . runNakadiT conf $ do
                               }
   withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
     liftIO $ link asyncHandle
-    eventConsumed :: Maybe (EventStreamBatch (DataChangeEvent Foo)) <-
+    (Just batchConsumed) :: Maybe (EventStreamBatch (DataChangeEvent Foo)) <-
       eventsProcessConduit (Just consumeParametersSingle) myEventTypeName Nothing headC
-    liftIO $ isJust eventConsumed @=? True
+    liftIO $ isJust (batchConsumed^.L.events) @=? True
 
 testEventTypeParseFlowId :: Config App -> Assertion
 testEventTypeParseFlowId conf = runApp . runNakadiT conf $ do
@@ -145,18 +146,41 @@ testEventTypeParseFlowId conf = runApp . runNakadiT conf $ do
       expectedFlowId = Just $ FlowId "12345"
   withAsync (delayedPublish expectedFlowId [event]) $ \asyncHandle -> do
     liftIO $ link asyncHandle
-    eventConsumed :: Maybe (EventStreamBatch (DataChangeEventEnriched Foo)) <-
+    Just batchConsumed :: Maybe (EventStreamBatch (DataChangeEventEnriched Foo)) <-
       eventsProcessConduit (Just consumeParametersSingle) myEventTypeName Nothing headC
-    liftIO $ isJust eventConsumed @=? True
-    let events = eventConsumed >>= (\batch -> batch^.L.events)
-    liftIO $ isJust events @=? True
+    let (Just events) = (batchConsumed^.L.events)
+    liftIO $ case toList events of
+      [DataChangeEventEnriched _ x _ _] ->
+        x^.L.flowId @=? expectedFlowId
+      [] -> assertFailure "Received no events"
+      _ -> assertFailure "Did not receive a singleton event list"
 
-    liftIO $ case events of
-      Nothing -> assertFailure "Received no events"
-      Just v -> case toList v of
-        [DataChangeEventEnriched _ x _ _] ->
-          x^.L.flowId @=? expectedFlowId
-        _ -> assertFailure "Received not a singleton event list"
+testEventTypeDeserializationFailureException :: Config App -> Assertion
+testEventTypeDeserializationFailureException conf = runApp . runNakadiT conf $ do
+  now <- liftIO getCurrentTime
+  eid <- EventId <$> genRandomUUID
+  eventTypeDelete myEventTypeName `catch` (ignoreExnNotFound ())
+  eventTypeCreate myEventType
+  let event = DataChangeEvent { _payload = Foo "Hello!"
+                              , _metadata = EventMetadata { _eid = eid
+                                                          , _occurredAt = Timestamp now
+                                                          , _parentEids = Nothing
+                                                          , _partition  = Nothing
+                                                          }
+                              , _dataType = "test.FOO"
+                              , _dataOp = DataOpUpdate
+                              }
+  res :: Either NakadiException (Maybe (EventStreamBatch WrongFoo)) <- try $
+    withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
+    liftIO $ link asyncHandle
+    eventsProcessConduit (Just consumeParametersSingle) myEventTypeName Nothing headC
+  case res of
+    Left (DeserializationFailure _ _) ->
+      pure ()
+    Left exn ->
+      liftIO $ assertFailure $ "Unexpected exception: " <> show exn
+    Right events ->
+      liftIO $ assertFailure $ "Unexpected success: " <> show events
 
 testEventTypeDeserializationFailure :: Config App -> Assertion
 testEventTypeDeserializationFailure conf' = runApp . runNakadiT conf $ do


### PR DESCRIPTION
 If no callback is set, throw `DeserialiationFailure` exception.
Change this exception to also include a reason of failure, not only the bytestring which causes the failure.

This takes care of #68.

Can you review, @amrhassan ?
