### PR TITLE
Put version constraint on conduit-combinators

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: nakadi-client
-version: '0.5.0.0'
+version: '0.5.0.1'
 synopsis: Client library for the Nakadi Event Broker
 description: This package implements a client library for interacting
              with the Nakadi event broker system developed by Zalando.
@@ -38,7 +38,7 @@ dependencies:
 - transformers-base
 - conduit
 - conduit-extra
-- conduit-combinators
+- conduit-combinators >= 1.1.2 && < 1.3.0
 - iso8601-time
 - bytestring
 - containers


### PR DESCRIPTION
The most recent version of conduit-combinators (1.3.0) is deprecated.

In the future we will simply use the conduit package including its recently updated dependencies (unliftio, stm-conduit, etc.) but right now we should simply get Hackage builds to succeed again.

I hope that this patch is sufficient.

See https://hackage.haskell.org/package/conduit-combinators-1.3.0
and https://hackage.haskell.org/package/nakadi-client-0.5.0.0/reports/2
