### PR TITLE
Implement foundation for different cursor commit strategies

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: nakadi-client
-version: '0.5.0.3'
+version: '0.5.1.0'
 synopsis: Client library for the Nakadi Event Broker
 description: This package implements a client library for interacting
              with the Nakadi event broker system developed by Zalando.
@@ -66,6 +66,8 @@ dependencies:
 - template-haskell
 - retry
 - unliftio-core
+- stm
+- lifted-async >= 0.10.0 && < 0.11
 library:
   source-dirs: src
   exposed-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -9,6 +9,7 @@ maintainer: mtesseract@silverratio.net
 copyright: (c) 2017, 2018 Moritz Clasmeier
 license: BSD3
 github: mtesseract/nakadi-haskell
+homepage: http://nakadi-client.haskell.silverratio.net
 extra-source-files:
 - README.md
 - AUTHORS.md
@@ -58,7 +59,7 @@ dependencies:
 - transformers
 - scientific
 - exceptions
-- safe-exceptions
+- safe-exceptions >= 0.1.7.0 && < 0.2
 - unordered-containers
 - time
 - split
@@ -67,7 +68,8 @@ dependencies:
 - retry
 - unliftio-core
 - stm
-- lifted-async >= 0.10.0 && < 0.11
+- unliftio >= 0.2.4.0 && < 0.3
+- async-timer >= 0.2.0.0 && < 0.3
 library:
   source-dirs: src
   exposed-modules:

--- a/src/Network/Nakadi/Config.hs
+++ b/src/Network/Nakadi/Config.hs
@@ -29,6 +29,7 @@ module Network.Nakadi.Config
   , setStreamTimeout
   , setStreamKeepAliveLimit
   , setFlowId
+  , setCommitStrategy
   , defaultConsumeParameters
   ) where
 
@@ -47,6 +48,10 @@ import           Network.Nakadi.Internal.Types
 -- | Default retry policy.
 defaultRetryPolicy :: MonadIO m => RetryPolicyM m
 defaultRetryPolicy = fullJitterBackoff 2 <> limitRetries 5
+
+-- | Default commit strategy.
+defaultCommitStrategy :: CommitStrategy
+defaultCommitStrategy = CommitSyncUnbuffered
 
 -- | Producs a new configuration, with mandatory HTTP manager, default
 -- consumption parameters and HTTP request template.
@@ -67,6 +72,7 @@ newConfig httpBackend request =
          , _http                           = httpBackend
          , _httpErrorCallback              = Nothing
          , _flowId                         = Nothing
+         , _commitStrategy                 = defaultCommitStrategy
          }
 
 -- | Producs a new configuration, with mandatory HTTP manager, default
@@ -152,6 +158,13 @@ setFlowId
   -> Config m
   -> Config m
 setFlowId flowId = L.flowId .~ Just flowId
+
+-- | Set flow ID in the provided configuration.
+setCommitStrategy
+  :: CommitStrategy
+  -> Config m
+  -> Config m
+setCommitStrategy = (L.commitStrategy .~)
 
 -- | Set maximum number of uncommitted events in the provided value of
 -- consumption parameters.

--- a/src/Network/Nakadi/Config.hs
+++ b/src/Network/Nakadi/Config.hs
@@ -51,7 +51,7 @@ defaultRetryPolicy = fullJitterBackoff 2 <> limitRetries 5
 
 -- | Default commit strategy.
 defaultCommitStrategy :: CommitStrategy
-defaultCommitStrategy = CommitSyncUnbuffered
+defaultCommitStrategy = CommitSync
 
 -- | Producs a new configuration, with mandatory HTTP manager, default
 -- consumption parameters and HTTP request template.

--- a/src/Network/Nakadi/Internal/Lenses.hs
+++ b/src/Network/Nakadi/Internal/Lenses.hs
@@ -54,6 +54,7 @@ makeNakadiLenses ''PaginationLinks
 makeNakadiLenses ''SubscriptionEventTypeStatsResult
 makeNakadiLenses ''ConsumeParameters
 makeNakadiLenses ''SubscriptionCursorCommit
+makeNakadiLenses ''SubscriptionCursor
 makeNakadiLenses ''CursorCommit
 makeNakadiLenses ''SubscriptionsListResponse
 makeNakadiLenses ''Subscription

--- a/src/Network/Nakadi/Internal/Types.hs
+++ b/src/Network/Nakadi/Internal/Types.hs
@@ -32,6 +32,7 @@ module Network.Nakadi.Internal.Types
   , module Network.Nakadi.Internal.Types.Service
   , module Network.Nakadi.Internal.Types.Util
   , module Network.Nakadi.Internal.Types.Base
+  , module Network.Nakadi.Internal.Types.Subscriptions
   , HasNakadiConfig(..)
   , MonadNakadi(..)
   , MonadNakadiIO
@@ -60,6 +61,7 @@ import           Network.Nakadi.Internal.Types.Logger
 import           Network.Nakadi.Internal.Types.Problem
 import           Network.Nakadi.Internal.Types.Service
 import           Network.Nakadi.Internal.Types.Util
+import           Network.Nakadi.Internal.Types.Subscriptions
 
 -- * Define Typeclasses
 

--- a/src/Network/Nakadi/Internal/Types/Config.hs
+++ b/src/Network/Nakadi/Internal/Types/Config.hs
@@ -18,11 +18,12 @@ module Network.Nakadi.Internal.Types.Config where
 
 import           Conduit
 import           Control.Retry
-import qualified Data.ByteString.Lazy                  as LB
+import qualified Data.ByteString.Lazy                        as LB
 import           Network.HTTP.Client
 import           Network.Nakadi.Internal.Prelude
 import           Network.Nakadi.Internal.Types.Logger
 import           Network.Nakadi.Internal.Types.Service
+import           Network.Nakadi.Internal.Types.Subscriptions
 
 -- | Config
 
@@ -46,6 +47,7 @@ data Config m where
             , _http                           :: HttpBackend m
             , _httpErrorCallback              :: Maybe (HttpErrorCallback m)
             , _flowId                         :: Maybe FlowId
+            , _commitStrategy                 :: CommitStrategy
             } -> Config m
 
 -- | ConsumeParameters

--- a/src/Network/Nakadi/Internal/Types/Subscriptions.hs
+++ b/src/Network/Nakadi/Internal/Types/Subscriptions.hs
@@ -13,8 +13,28 @@ subscriptions, which are not modelled after the Nakadi API.
 
 module Network.Nakadi.Internal.Types.Subscriptions where
 
+import           Data.Int
+
+
 -- | This type encodes the supported strategies for subscription
 -- cursor committing.
 data CommitStrategy
-  = CommitSyncUnbuffered -- ^ This strategy synchronously commit every
-                         -- cursor.
+  = CommitSync                          -- ^ This strategy synchronously commits every
+                                        -- cursor.
+  | CommitAsync CommitBufferingStrategy -- ^ This strategy sends cursors to be
+                                        -- committed to a dedicated thread
+                                        -- responsible for committing them. Cursors
+                                        -- are commited one by one, without special
+                                        -- buffering logic.
+
+-- | This type encodes the supported buffering strategies for
+-- asynchronous subscription cursor committing.
+data CommitBufferingStrategy
+  = CommitNoBuffer         -- ^ No buffering at all.
+  | CommitTimeBuffer Int32 -- ^ Buffer for the specified duration,
+                           -- given in milliseconds.
+  | CommitSmartBuffer      -- ^ Buffer for a fixed duration, but
+                           -- committing cursors immediately if the
+                           -- number of events processed since the
+                           -- last commit crosses a threshold derived
+                           -- from @maxUncommittedEvents@.

--- a/src/Network/Nakadi/Internal/Types/Subscriptions.hs
+++ b/src/Network/Nakadi/Internal/Types/Subscriptions.hs
@@ -1,0 +1,20 @@
+{-|
+Module      : Network.Nakadi.Types.Subscriptions
+Description : Nakadi Service Types
+Copyright   : (c) Moritz Clasmeier 2018
+License     : BSD3
+Maintainer  : mtesseract@silverratio.net
+Stability   : experimental
+Portability : POSIX
+
+This module defines types, which are related to consumption of
+subscriptions, which are not modelled after the Nakadi API.
+-}
+
+module Network.Nakadi.Internal.Types.Subscriptions where
+
+-- | This type encodes the supported strategies for subscription
+-- cursor committing.
+data CommitStrategy
+  = CommitSyncUnbuffered -- ^ This strategy synchronously commit every
+                         -- cursor.

--- a/src/Network/Nakadi/Subscriptions/Events.hs
+++ b/src/Network/Nakadi/Subscriptions/Events.hs
@@ -25,32 +25,49 @@ module Network.Nakadi.Subscriptions.Events
 import           Network.Nakadi.Internal.Prelude
 
 import           Conduit                              hiding (throwM)
+import           Control.Concurrent.Async.Lifted      (link, withAsync)
+import           Control.Concurrent.STM               (TBQueue, atomically,
+                                                       newTBQueue, readTBQueue,
+                                                       writeTBQueue)
+import           Control.Lens
 import           Data.Aeson
-import           Data.Void
+import qualified Data.Conduit.List                    as Conduit (map, mapM_)
 import           Network.HTTP.Client                  (responseBody)
 import           Network.HTTP.Simple
 import           Network.HTTP.Types
-
 import           Network.Nakadi.Internal.Config
 import           Network.Nakadi.Internal.Conversions
 import           Network.Nakadi.Internal.Http
 import qualified Network.Nakadi.Internal.Lenses       as L
 import           Network.Nakadi.Subscriptions.Cursors
 
+-- | Consumes the specified subscription using the commit strategy
+-- contained in the configuration. Each consumed batch of subscription
+-- events is provided to the provided batch processor action. If this
+-- action throws an exception, subscription consumtion will terminate.
 subscriptionProcess
   :: ( MonadNakadi b m
+     , MonadIO m
+     , MonadBaseControl IO m
      , MonadMask m
      , FromJSON a )
   => Maybe ConsumeParameters
-  -> SubscriptionId
-  -> (SubscriptionEventStreamBatch a -> m ())
+  -> SubscriptionId                           -- ^ Subscription to consume
+  -> (SubscriptionEventStreamBatch a -> m ()) -- ^ Batch processor action
   -> m ()
 subscriptionProcess maybeConsumeParameters subscriptionId processor =
   subscriptionProcessConduit maybeConsumeParameters subscriptionId conduit
   where conduit = iterMC processor
 
+-- | Conduit based interface for subscription consumption. Consumes
+-- the specified subscription using the commit strategy contained in
+-- the configuration. Each consumed event batch is then processed by
+-- the provided conduit. If an exception is thrown inside the conduit,
+-- subscription consumtion will terminate.
 subscriptionProcessConduit
   :: ( MonadNakadi b m
+     , MonadIO m
+     , MonadBaseControl IO m
      , MonadMask m
      , FromJSON a
      , L.HasNakadiSubscriptionCursor c )
@@ -68,7 +85,6 @@ subscriptionProcessConduit maybeConsumeParameters subscriptionId processor = do
      . setRequestQueryParameters queryParams) $
     handler config
 
-
   where buildSubscriptionEventStream response =
           case listToMaybe (getResponseHeader "X-Nakadi-StreamId" response) of
             Just streamId ->
@@ -84,20 +100,26 @@ subscriptionProcessConduit maybeConsumeParameters subscriptionId processor = do
 
         handler config response = do
           eventStream <- buildSubscriptionEventStream response
-          runConduit $
-            responseBody response
-            .| linesUnboundedAsciiC
-            .| conduitDecode config
-            .| processor
-            .| subscriptionSink eventStream
+          queue <- liftIO . atomically $ newTBQueue 1024
+          withAsync (subscriptionCommitter (config^.L.commitStrategy) eventStream queue) $
+            \ asyncHandle -> do
+              link asyncHandle
+              runConduit $
+                responseBody response
+                .| linesUnboundedAsciiC
+                .| conduitDecode config
+                .| processor
+                .| Conduit.map (view L.subscriptionCursor)
+                .| Conduit.mapM_ (liftIO . atomically . writeTBQueue queue)
 
-
--- | Sink which can be used as sink for Conduits processing
--- subscriptions events. This sink takes care of committing events. It
--- can consume any values which contain Subscription Cursors.
-subscriptionSink ::
-  (MonadNakadi b m, L.HasNakadiSubscriptionCursor a)
-  => SubscriptionEventStream
-  -> ConduitM a Void m ()
-subscriptionSink eventStream =
-  awaitForever $ lift . subscriptionCursorCommit eventStream . (: [])
+subscriptionCommitter
+  :: (MonadIO m, MonadNakadi b m)
+  => CommitStrategy
+  -> SubscriptionEventStream
+  -> TBQueue SubscriptionCursor
+  -> m ()
+subscriptionCommitter CommitSyncUnbuffered eventStream queue = go
+  where go = do
+          a <- liftIO . atomically . readTBQueue $ queue
+          subscriptionCursorCommit eventStream [a]
+          go

--- a/src/Network/Nakadi/Subscriptions/Events.hs
+++ b/src/Network/Nakadi/Subscriptions/Events.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Network.Nakadi.Subscriptions.Events
 Description : Implementation of Nakadi Subscription Events API
-Copyright   : (c) Moritz Schulte 2017, 2018
+Copyright   : (c) Moritz Clasmeier 2017, 2018
 License     : BSD3
 Maintainer  : mtesseract@silverratio.net
 Stability   : experimental
@@ -13,6 +13,8 @@ This module implements a high level interface for the
 
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -25,13 +27,22 @@ module Network.Nakadi.Subscriptions.Events
 import           Network.Nakadi.Internal.Prelude
 
 import           Conduit                              hiding (throwM)
-import           Control.Concurrent.Async.Lifted      (link, withAsync)
-import           Control.Concurrent.STM               (TBQueue, atomically,
-                                                       newTBQueue, readTBQueue,
-                                                       writeTBQueue)
+import qualified Control.Concurrent.Async.Timer       as Timer
+import           Control.Concurrent.STM               (TBQueue, TVar,
+                                                       atomically, modifyTVar,
+                                                       newTBQueue, newTVar,
+                                                       readTBQueue, readTVar,
+                                                       retry, swapTVar,
+                                                       writeTBQueue, writeTVar)
 import           Control.Lens
+import           Control.Monad.IO.Unlift
+import           Control.Monad.Logger
 import           Data.Aeson
-import qualified Data.Conduit.List                    as Conduit (map, mapM_)
+import qualified Data.Conduit.List                    as Conduit (mapM_)
+import           Data.HashMap.Strict                  (HashMap)
+import qualified Data.HashMap.Strict                  as HashMap
+import           Data.List                            (partition)
+import qualified Data.Vector                          as Vector
 import           Network.HTTP.Client                  (responseBody)
 import           Network.HTTP.Simple
 import           Network.HTTP.Types
@@ -40,18 +51,19 @@ import           Network.Nakadi.Internal.Conversions
 import           Network.Nakadi.Internal.Http
 import qualified Network.Nakadi.Internal.Lenses       as L
 import           Network.Nakadi.Subscriptions.Cursors
+import           UnliftIO.Async
 
 -- | Consumes the specified subscription using the commit strategy
 -- contained in the configuration. Each consumed batch of subscription
 -- events is provided to the provided batch processor action. If this
--- action throws an exception, subscription consumtion will terminate.
+-- action throws an exception, subscription consumption will terminate.
 subscriptionProcess
   :: ( MonadNakadi b m
-     , MonadIO m
-     , MonadBaseControl IO m
+     , MonadUnliftIO m
      , MonadMask m
      , FromJSON a )
-  => Maybe ConsumeParameters
+  => Maybe ConsumeParameters                  -- ^ 'ConsumeParameters'
+                                              -- to use
   -> SubscriptionId                           -- ^ Subscription to consume
   -> (SubscriptionEventStreamBatch a -> m ()) -- ^ Batch processor action
   -> m ()
@@ -63,17 +75,16 @@ subscriptionProcess maybeConsumeParameters subscriptionId processor =
 -- the specified subscription using the commit strategy contained in
 -- the configuration. Each consumed event batch is then processed by
 -- the provided conduit. If an exception is thrown inside the conduit,
--- subscription consumtion will terminate.
+-- subscription consumption will terminate.
 subscriptionProcessConduit
   :: ( MonadNakadi b m
-     , MonadIO m
-     , MonadBaseControl IO m
+     , MonadUnliftIO m
      , MonadMask m
      , FromJSON a
-     , L.HasNakadiSubscriptionCursor c )
-  => Maybe ConsumeParameters
-  -> SubscriptionId
-  -> ConduitM (SubscriptionEventStreamBatch a) c m ()
+     , batch ~ SubscriptionEventStreamBatch a )
+  => Maybe ConsumeParameters   -- ^ 'ConsumeParameters' to use
+  -> SubscriptionId            -- ^ Subscription to consume
+  -> ConduitM batch batch m () -- ^ Conduit processor.
   -> m ()
 subscriptionProcessConduit maybeConsumeParameters subscriptionId processor = do
   config <- nakadiAsk
@@ -83,43 +94,224 @@ subscriptionProcessConduit maybeConsumeParameters subscriptionId processor = do
     (includeFlowId config
      . setRequestPath path
      . setRequestQueryParameters queryParams) $
-    handler config
+    subscriptionProcessHandler subscriptionId processor
 
-  where buildSubscriptionEventStream response =
-          case listToMaybe (getResponseHeader "X-Nakadi-StreamId" response) of
-            Just streamId ->
-              pure SubscriptionEventStream
-              { _streamId       = StreamId (decodeUtf8 streamId)
-              , _subscriptionId = subscriptionId }
-            Nothing ->
-              throwM StreamIdMissing
-
-        path = "/subscriptions/"
+  where path = "/subscriptions/"
                <> subscriptionIdToByteString subscriptionId
                <> "/events"
 
-        handler config response = do
-          eventStream <- buildSubscriptionEventStream response
-          queue <- liftIO . atomically $ newTBQueue 1024
-          withAsync (subscriptionCommitter (config^.L.commitStrategy) eventStream queue) $
-            \ asyncHandle -> do
-              link asyncHandle
-              runConduit $
-                responseBody response
-                .| linesUnboundedAsciiC
-                .| conduitDecode config
-                .| processor
-                .| Conduit.map (view L.subscriptionCursor)
-                .| Conduit.mapM_ (liftIO . atomically . writeTBQueue queue)
+-- | Derive a 'SubscriptionEventStream' from the provided
+-- 'SubscriptionId' and Nakadi streaming response.
+buildSubscriptionEventStream
+  :: MonadThrow m
+  => SubscriptionId
+  -> Response a
+  -> m SubscriptionEventStream
+buildSubscriptionEventStream subscriptionId response =
+  case listToMaybe (getResponseHeader "X-Nakadi-StreamId" response) of
+    Just streamId ->
+      pure SubscriptionEventStream
+      { _streamId       = StreamId (decodeUtf8 streamId)
+      , _subscriptionId = subscriptionId }
+    Nothing ->
+      throwM StreamIdMissing
 
-subscriptionCommitter
-  :: (MonadIO m, MonadNakadi b m)
-  => CommitStrategy
-  -> SubscriptionEventStream
-  -> TBQueue SubscriptionCursor
+-- | This function processes a subscription, taking care of applying
+-- the configured committing strategy.
+subscriptionProcessHandler
+  :: ( MonadNakadi b m
+     , MonadUnliftIO m
+     , MonadMask m
+     , FromJSON a
+     , batch ~ (SubscriptionEventStreamBatch a) )
+  => SubscriptionId                         -- ^ Subscription ID required for committing.
+  -> ConduitM batch batch m ()              -- ^ User provided Conduit for stream.
+  -> Response (ConduitM () ByteString m ()) -- ^ Streaming response from Nakadi
   -> m ()
-subscriptionCommitter CommitSyncUnbuffered eventStream queue = go
-  where go = do
-          a <- liftIO . atomically . readTBQueue $ queue
-          subscriptionCursorCommit eventStream [a]
-          go
+subscriptionProcessHandler subscriptionId processor response = do
+  config      <- nakadiAsk
+  eventStream <- buildSubscriptionEventStream subscriptionId response
+  let producer = responseBody response
+                 .| linesUnboundedAsciiC
+                 .| conduitDecode config
+                 .| processor
+  case config^.L.commitStrategy of
+    CommitSync ->
+      -- Synchronous case: Simply use a Conduit sink that commits
+      -- every cursor.
+      runConduit $ producer .| subscriptionSink eventStream
+    CommitAsync bufferingStrategy -> do
+      -- Asynchronous case: Create a new queue and spawn a cursor
+      -- committer thread depending on the configured commit buffering
+      -- method. Then execute the provided Conduit processor with a
+      -- sink that sends cursor information to the queue. The cursor
+      -- committer thread reads from this queue and processes the
+      -- cursors.
+      queue <- liftIO . atomically $ newTBQueue 1024
+      withAsync (subscriptionCommitter bufferingStrategy eventStream queue) $
+        \ asyncHandle -> do
+          link asyncHandle
+          runConduit $ producer .| Conduit.mapM_ (sendToQueue queue)
+
+  where sendToQueue queue batch = liftIO . atomically $ do
+          let cursor  = batch^.L.cursor
+              events  = fromMaybe Vector.empty (batch^.L.events)
+              nEvents = length events
+          writeTBQueue queue (nEvents, cursor)
+
+-- | Sink which can be used as sink for Conduits processing
+-- subscriptions events. This sink takes care of committing events. It
+-- can consume any values which contain Subscription Cursors.
+subscriptionSink
+  :: (MonadIO m, MonadNakadi b m)
+  => SubscriptionEventStream
+  -> ConduitM (SubscriptionEventStreamBatch a) void m ()
+subscriptionSink eventStream = do
+  config <- lift nakadiAsk
+  awaitForever $ \ batch -> lift $ do
+    let cursor  = batch^.L.cursor
+    catchAny (commitOneCursor eventStream cursor) $ \ exn -> nakadiLiftBase $
+      case config^.L.logFunc of
+        Just logFunc -> logFunc "nakadi-client" LevelWarn $ toLogStr $
+          "Failed to synchronously commit cursor: " <> tshow exn
+        Nothing ->
+          pure ()
+
+-- | Main function for the cursor committer thread. Logic depends on
+-- the provided buffering strategy.
+subscriptionCommitter
+  :: ( MonadNakadi b m
+     , MonadUnliftIO m
+     , MonadMask m )
+  => CommitBufferingStrategy
+  -> SubscriptionEventStream
+  -> TBQueue (Int, SubscriptionCursor)
+  -> m ()
+
+-- | Implementation for the 'CommitNoBuffer' strategy: We simply read
+-- every cursor and commit it in order.
+subscriptionCommitter CommitNoBuffer eventStream queue = loop
+  where loop = do
+          config <- nakadiAsk
+          (_nEvents, cursor) <- liftIO . atomically . readTBQueue $ queue
+          catchAny (subscriptionCursorCommit eventStream [cursor]) $ \ exn -> do
+            nakadiLiftBase $
+              case config^.L.logFunc of
+                Just logFunc -> logFunc "nakadi-client" LevelWarn $ toLogStr $
+                  "Failed to commit cursor " <> tshow cursor <> ": " <> tshow exn
+                Nothing ->
+                  pure ()
+          loop
+
+-- | Implementation of the 'CommitTimeBuffer' strategy: We use an
+-- async timer for committing cursors at specified intervals.
+subscriptionCommitter (CommitTimeBuffer millis) eventStream queue = do
+  let timerConf = Timer.defaultConf
+                  & Timer.setInitDelay (fromIntegral millis)
+                  & Timer.setInterval  (fromIntegral millis)
+  cursorsMap <- liftIO . atomically $
+                newTVar (HashMap.empty :: HashMap PartitionName (Int, SubscriptionCursor))
+  withAsync (cursorConsumer cursorsMap) $ \ asyncCursorConsumer -> do
+    link asyncCursorConsumer
+    Timer.withAsyncTimer timerConf $ \ timer -> forever $ do
+      Timer.wait timer
+      commitAllCursors eventStream cursorsMap
+
+  where -- | The cursorsConsumer drains the cursors queue and adds each
+        -- cursor to the provided cursorsMap.
+        cursorConsumer cursorsMap = forever . liftIO . atomically $ do
+          (_, cursor) <- readTBQueue queue
+          modifyTVar cursorsMap (HashMap.insert (cursor^.L.partition) (0, cursor))
+
+-- | Implementation of the 'CommitSmartBuffer' strategy: We use an
+-- async timer for committing cursors at specified intervals, but if
+-- the number of uncommitted events reaches some threshold before the
+-- next scheduled commit, a commit is being done right away and the
+-- timer is resetted.
+subscriptionCommitter CommitSmartBuffer eventStream queue = do
+  config <- nakadiAsk
+  let millisDefault               = 1000
+      nMaxUncommitedEventsDefault = 1000
+      consumeParameters           = fromMaybe defaultConsumeParameters $
+                                    config^.L.consumeParameters
+      nMaxUncommittedEvents       = case consumeParameters^.L.maxUncommittedEvents of
+                                      Just n  -> n
+                                      Nothing -> nMaxUncommitedEventsDefault
+      nMaxEvents                  = fromIntegral $ nMaxUncommittedEvents `div` 2
+      timerConf                   = Timer.defaultConf
+                                    & Timer.setInitDelay (fromIntegral millisDefault)
+                                    & Timer.setInterval  (fromIntegral millisDefault)
+  cursorsMap <- liftIO . atomically $
+                newTVar (HashMap.empty :: HashMap PartitionName (Int, SubscriptionCursor))
+  withAsync (cursorConsumer cursorsMap) $ \ asyncCursorConsumer -> do
+    link asyncCursorConsumer
+    Timer.withAsyncTimer timerConf $ cursorCommitter cursorsMap nMaxEvents
+
+  where -- The cursorsConsumer drains the cursors queue and adds each
+        -- cursor to the provided cursorsMap.
+        cursorConsumer cursorsMap = forever . liftIO . atomically $ do
+          (nEvents, cursor) <- readTBQueue queue
+          modifyTVar cursorsMap (HashMap.insertWith updateCursor (cursor^.L.partition) (nEvents, cursor))
+
+        -- | Adds the old number of events to the new entry in the
+        -- cursors map.
+        updateCursor cursorNew _cursorOld @ (nEventsOld, _) =
+          cursorNew & _1 %~ (+ nEventsOld)
+
+        -- | Committer loop.
+        cursorCommitter cursorsMap nMaxEvents timer = forever $  do
+          race (Timer.wait timer) (maxEventsReached cursorsMap nMaxEvents) >>= \ case
+            Left _ ->
+              -- Timer has elapsed, simply commit all currently
+              -- buffered cursors.
+              commitAllCursors eventStream cursorsMap
+            Right cursors -> do
+              -- Events processed since last cursor commit have
+              -- crosses configured threshold for at least one
+              -- partition. Commit cursors on all such partitions.
+              Timer.reset timer
+              forM_ cursors (commitOneCursor eventStream)
+
+        -- | Returns list of cursors that should be committed
+        -- considering the number of events processed on the
+        -- respective partition since the last commit. Blocks until at
+        -- least one such cursor is found.
+        maxEventsReached cursorsMap nMaxEvents = liftIO . atomically $ do
+          cursorsList <- HashMap.toList <$> readTVar cursorsMap
+          let (cursorsCommit, cursorsNotCommit) = partition (shouldBeCommitted nMaxEvents) cursorsList
+          if null cursorsCommit
+            then retry
+            else do writeTVar cursorsMap (HashMap.fromList cursorsNotCommit)
+                    pure $ map (view (_2._2)) cursorsCommit
+
+
+        -- | Returns True if the provided cursor should be committed.
+        shouldBeCommitted nMaxEvents cursor = cursor^._2._1  >= nMaxEvents
+
+-- | This function commits all cursors in the provided cursorsMap.
+commitAllCursors
+  :: (MonadNakadi b m, MonadIO m)
+  => SubscriptionEventStream
+  -> TVar (HashMap PartitionName (Int, SubscriptionCursor))
+  -> m ()
+commitAllCursors eventStream cursorsMap = do
+  cursors <- liftIO . atomically $ swapTVar cursorsMap HashMap.empty
+  forM_ cursors $ \ (_nEvents, cursor) -> commitOneCursor eventStream cursor
+
+
+-- | This function takes care of committing a single cursor. Exceptions will be
+-- catched and logged, but the failure will NOT be propagated. This means that
+-- Nakadi itself is in control of disconnecting us.
+commitOneCursor
+  :: (MonadIO m, MonadNakadi b m)
+  => SubscriptionEventStream
+  -> SubscriptionCursor
+  -> m ()
+commitOneCursor eventStream cursor = do
+  config <- nakadiAsk
+  catchAny (subscriptionCursorCommit eventStream [cursor]) $ \ exn -> nakadiLiftBase $
+    case config^.L.logFunc of
+      Just logFunc -> logFunc "nakadi-client" LevelWarn $ toLogStr $
+        "Failed to commit cursor " <> tshow cursor <> ": " <> tshow exn
+      Nothing ->
+        pure ()

--- a/src/Network/Nakadi/Types.hs
+++ b/src/Network/Nakadi/Types.hs
@@ -16,6 +16,7 @@ module Network.Nakadi.Types
   , module Network.Nakadi.Types.Logger
   , module Network.Nakadi.Types.Problem
   , module Network.Nakadi.Types.Service
+  , module Network.Nakadi.Types.Subscriptions
   , MonadNakadiBase(..)
   , MonadNakadi(..)
   , HasNakadiConfig(..)
@@ -30,3 +31,4 @@ import           Network.Nakadi.Types.Exceptions
 import           Network.Nakadi.Types.Logger
 import           Network.Nakadi.Types.Problem
 import           Network.Nakadi.Types.Service
+import           Network.Nakadi.Types.Subscriptions

--- a/src/Network/Nakadi/Types/Subscriptions.hs
+++ b/src/Network/Nakadi/Types/Subscriptions.hs
@@ -13,6 +13,7 @@ subscriptions, which are not modelled after the Nakadi API.
 
 module Network.Nakadi.Types.Subscriptions
   ( CommitStrategy(..)
+  , CommitBufferingStrategy(..)
   ) where
 
 import           Network.Nakadi.Internal.Types.Subscriptions

--- a/src/Network/Nakadi/Types/Subscriptions.hs
+++ b/src/Network/Nakadi/Types/Subscriptions.hs
@@ -1,0 +1,18 @@
+{-|
+Module      : Network.Nakadi.Types.Subscriptions
+Description : Nakadi Service Subscription Types
+Copyright   : (c) Moritz Clasmeier 2018
+License     : BSD3
+Maintainer  : mtesseract@silverratio.net
+Stability   : experimental
+Portability : POSIX
+
+This module exposes types, which are related to consumption of
+subscriptions, which are not modelled after the Nakadi API.
+-}
+
+module Network.Nakadi.Types.Subscriptions
+  ( CommitStrategy(..)
+  ) where
+
+import           Network.Nakadi.Internal.Types.Subscriptions

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
-resolver: lts-10.5
+resolver: lts-10.6
 packages:
 - '.'
-extra-deps: []
+extra-deps: [async-2.2.1, lifted-async-0.10.0]
 flags: {}
 extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
-resolver: lts-10.6
+resolver: lts-10.7
 packages:
 - '.'
-extra-deps: [async-2.2.1, lifted-async-0.10.0]
+extra-deps: [async-2.2.1, lifted-async-0.10.0, async-timer-0.2.0.0, unliftio-0.2.4.0, safe-exceptions-0.1.7.0]
 flags: {}
 extra-package-dbs: []

--- a/tests/Network/Nakadi/Examples/Subscription/Process.hs
+++ b/tests/Network/Nakadi/Examples/Subscription/Process.hs
@@ -7,8 +7,9 @@ import           Data.Aeson
 import qualified Network.Nakadi as Nakadi
 import Network.Nakadi (MonadNakadi)
 import Control.Monad.Logger
+import Control.Monad.IO.Unlift
 
-dumpSubscription :: (MonadLogger m, MonadNakadi IO m, MonadIO m, MonadBaseControl IO m, MonadMask m)
+dumpSubscription :: (MonadLogger m, MonadNakadi IO m, MonadUnliftIO m, MonadMask m)
                  => Nakadi.SubscriptionId -> m ()
 dumpSubscription subscriptionId =
   Nakadi.subscriptionProcess Nothing subscriptionId processBatch

--- a/tests/Network/Nakadi/Examples/Subscription/Process.hs
+++ b/tests/Network/Nakadi/Examples/Subscription/Process.hs
@@ -8,7 +8,8 @@ import qualified Network.Nakadi as Nakadi
 import Network.Nakadi (MonadNakadi)
 import Control.Monad.Logger
 
-dumpSubscription :: (MonadLogger m, MonadNakadi IO m, MonadMask m) => Nakadi.SubscriptionId -> m ()
+dumpSubscription :: (MonadLogger m, MonadNakadi IO m, MonadIO m, MonadBaseControl IO m, MonadMask m)
+                 => Nakadi.SubscriptionId -> m ()
 dumpSubscription subscriptionId =
   Nakadi.subscriptionProcess Nothing subscriptionId processBatch
 

--- a/tests/Network/Nakadi/Subscriptions/Processing/Test.hs
+++ b/tests/Network/Nakadi/Subscriptions/Processing/Test.hs
@@ -2,16 +2,16 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 
-
--- This test tests the following the high-level subscription consumption.
+-- This test tests the high-level subscription consumption.
 
 module Network.Nakadi.Subscriptions.Processing.Test where
 
 import           ClassyPrelude
 
+import           Control.Concurrent.Async    (link)
 import           Control.Lens
+import           Control.Monad.Logger
 import           Data.Aeson
-import           Data.Conduit
 import           Data.Maybe                  (fromJust)
 import           Network.Nakadi
 import qualified Network.Nakadi.Lenses       as L
@@ -20,23 +20,35 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 
 testSubscriptionsProcessing :: Config App -> TestTree
-testSubscriptionsProcessing conf = testGroup "Processing"
-  [ testCase "SubscriptionProcessing" (testSubscriptionHighLevelProcessing conf)
-  ]
+testSubscriptionsProcessing confTemplate =
+  let mkConf commitStrategy = confTemplate
+                              & setCommitStrategy commitStrategy
+  in testGroup "Processing"
+     [ testCase "SubscriptionProcessing/async/TimeBuffer" $
+       testSubscriptionHighLevelProcessing (mkConf (CommitAsync (CommitTimeBuffer 200)))
+     , testCase "SubscriptionProcessing/sync" $
+       testSubscriptionHighLevelProcessing (mkConf CommitSync)
+     , testCase "SubscriptionProcessing/async/NoBuffer" $
+       testSubscriptionHighLevelProcessing (mkConf (CommitAsync CommitNoBuffer))
+     , testCase "SubscriptionProcessing/async/SmartBuffer" $
+       testSubscriptionHighLevelProcessing (mkConf (CommitAsync CommitSmartBuffer))
+     ]
 
 data ConsumptionDone = ConsumptionDone deriving (Show, Typeable)
-
 
 instance Exception ConsumptionDone
 
 testSubscriptionHighLevelProcessing :: Config App -> Assertion
-testSubscriptionHighLevelProcessing conf = runApp . runNakadiT conf $ do
-  counter <- newIORef 0
-  events <- sequence $
-    replicate nEvents genMyDataChangeEvent :: NakadiT App App [DataChangeEvent Foo]
-  publishAndConsume events counter `catch` \ (_exn :: ConsumptionDone) -> pure ()
-  eventsRead <- readIORef counter
-  liftIO $ nEvents @=? eventsRead
+testSubscriptionHighLevelProcessing conf = runApp $ do
+  logger <- askLoggerIO
+  let logFunc src lev str = liftIO $ logger defaultLoc src lev str
+  runNakadiT (conf & setLogFunc logFunc) $ do
+    counter <- newIORef 0
+    events <- sequence $
+      map genMyDataChangeEventIdx [1..nEvents] :: NakadiT App App [DataChangeEvent Foo]
+    publishAndConsume events counter `catch` \ (_exn :: ConsumptionDone) -> pure ()
+    eventsRead <- readIORef counter
+    liftIO $ nEvents @=? eventsRead
 
   where before :: MonadNakadi App m => m SubscriptionId
         before = do
@@ -58,80 +70,28 @@ testSubscriptionHighLevelProcessing conf = runApp . runNakadiT conf $ do
           eventTypeDelete myEventTypeName `catch` (ignoreExnNotFound ())
 
         nEvents :: Int
-        nEvents = 100
+        nEvents = 10000
 
-        publishAndConsume :: (ToJSON a, FromJSON a)
+        publishAndConsume :: (ToJSON a, FromJSON a, Show a)
                           => [DataChangeEvent a]
                           -> IORef Int
                           -> NakadiT App App ()
         publishAndConsume events counter =
           bracket before after $ \ subscriptionId -> do
           let n = length events
-          void . async $ delayedPublish Nothing events
-          subscriptionProcess (Just consumeParameters) subscriptionId $
-            \ (batch :: SubscriptionEventStreamBatch (DataChangeEvent Foo)) -> do
-              -- Make sure that we can use Nakadi from within the high
-              -- level processing callback:
-              void $ registryPartitionStrategies
-              let eventsReceived = fromMaybe mempty (batch^.L.events)
-              modifyIORef counter (+ (length eventsReceived))
-              eventsRead <- readIORef counter
-              when (n == eventsRead) $ throwM ConsumptionDone
+          publisherHandle <- async $ do
+            delayedPublish Nothing events
+          liftIO $ link publisherHandle
+          forever $ do
+            subscriptionProcess (Just consumeParameters) subscriptionId $
+              \ (batch :: SubscriptionEventStreamBatch (DataChangeEvent Foo)) -> do
+                let eventsReceived = fromMaybe mempty (batch^.L.events)
+                modifyIORef counter (+ (length eventsReceived))
+                eventsRead <- readIORef counter
+                when (n <= eventsRead) $ throwM ConsumptionDone
+            putStrLn $ "Subscription Processing terminated, will restart."
 
         consumeParameters = defaultConsumeParameters
                             & setBatchFlushTimeout 1
-                            & setBatchLimit 1
-
-testSubscriptionConduitProcessing :: Config App -> Assertion
-testSubscriptionConduitProcessing conf = runApp . runNakadiT conf $ do
-  counter <- newIORef 0
-  events <- sequence $
-    replicate nEvents genMyDataChangeEvent :: NakadiT App App [DataChangeEvent Foo]
-  publishAndConsume events counter `catch` \ (_exn :: ConsumptionDone) -> pure ()
-  eventsRead <- readIORef counter
-  liftIO $ nEvents @=? eventsRead
-
-  where before :: MonadNakadi App m => m SubscriptionId
-        before = do
-          recreateEvent myEventTypeName myEventType
-          subscription <- subscriptionCreate Subscription
-            { _id = Nothing
-            , _owningApplication = "test-suite"
-            , _eventTypes = [myEventTypeName]
-            , _consumerGroup = Nothing -- ??
-            , _createdAt = Nothing
-            , _readFrom = Just SubscriptionPositionEnd
-            , _initialCursors = Nothing
-            }
-          pure . fromJust $ subscription^.L.id
-
-        after :: MonadNakadi App m => SubscriptionId -> m ()
-        after subscriptionId = do
-          subscriptionDelete subscriptionId
-          eventTypeDelete myEventTypeName `catch` (ignoreExnNotFound ())
-
-        nEvents :: Int
-        nEvents = 100
-
-        publishAndConsume :: (ToJSON a, FromJSON a)
-                          => [DataChangeEvent a]
-                          -> IORef Int
-                          -> NakadiT App App ()
-        publishAndConsume events counter =
-          bracket before after $ \ subscriptionId -> do
-          let n = length events
-          void . async $ delayedPublish Nothing events
-          subscriptionProcessConduit (Just consumeParameters) subscriptionId $ do
-            awaitForever $ \ (batch :: SubscriptionEventStreamBatch (DataChangeEvent Foo)) -> do
-              -- Make sure that we can use Nakadi via lifting directly
-              -- from within the Conduit.
-              void $ lift registryPartitionStrategies
-              let eventsReceived = fromMaybe mempty (batch^.L.events)
-              modifyIORef counter (+ (length eventsReceived))
-              eventsRead <- readIORef counter
-              when (n == eventsRead) $ throwM ConsumptionDone
-              yield batch
-
-        consumeParameters = defaultConsumeParameters
-                            & setBatchFlushTimeout 1
-                            & setBatchLimit 1
+                            & setMaxUncommittedEvents 5000
+                            & setBatchLimit 10


### PR DESCRIPTION
New type: CommitStrategy
Include in Config
Default strategy reflects current behaviour: committing every cursor.
Can be extended with high-performance cursor committing strategies.
This is the first step towards #66.

@etorreborre @amrhassan 