### PR TITLE
Support time lag retrieval for subscription stats

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: nakadi-client
-version: '0.5.1.0'
+version: '0.5.2.0'
 synopsis: Client library for the Nakadi Event Broker
 description: This package implements a client library for interacting
              with the Nakadi event broker system developed by Zalando.

--- a/src/Network/Nakadi/Config.hs
+++ b/src/Network/Nakadi/Config.hs
@@ -31,18 +31,22 @@ module Network.Nakadi.Config
   , setFlowId
   , setCommitStrategy
   , defaultConsumeParameters
-  ) where
+  , setShowTimeLag
+  )
+where
 
 import           Network.Nakadi.Internal.Prelude
 
 import           Control.Lens
 import           Control.Retry
-import           Network.HTTP.Client                   (Manager,
-                                                        ManagerSettings)
-import           Network.HTTP.Client.TLS               (newTlsManagerWith)
+import           Network.HTTP.Client            ( Manager
+                                                , ManagerSettings
+                                                )
+import           Network.HTTP.Client.TLS        ( newTlsManagerWith )
 import           Network.Nakadi.Internal.Config
 import           Network.Nakadi.Internal.HttpBackendIO
-import qualified Network.Nakadi.Internal.Lenses        as L
+import qualified Network.Nakadi.Internal.Lenses
+                                               as L
 import           Network.Nakadi.Internal.Types
 
 -- | Default retry policy.
@@ -60,20 +64,21 @@ newConfig
   => HttpBackend b
   -> Request           -- ^ Request Template
   -> Config b          -- ^ Resulting Configuration
-newConfig httpBackend request =
-  Config { _consumeParameters              = Nothing
-         , _manager                        = Nothing
-         , _requestTemplate                = request
-         , _requestModifier                = pure
-         , _deserializationFailureCallback = Nothing
-         , _streamConnectCallback          = Nothing
-         , _logFunc                        = Nothing
-         , _retryPolicy                    = defaultRetryPolicy
-         , _http                           = httpBackend
-         , _httpErrorCallback              = Nothing
-         , _flowId                         = Nothing
-         , _commitStrategy                 = defaultCommitStrategy
-         }
+newConfig httpBackend request = Config
+  { _consumeParameters              = Nothing
+  , _manager                        = Nothing
+  , _requestTemplate                = request
+  , _requestModifier                = pure
+  , _deserializationFailureCallback = Nothing
+  , _streamConnectCallback          = Nothing
+  , _logFunc                        = Nothing
+  , _retryPolicy                    = defaultRetryPolicy
+  , _http                           = httpBackend
+  , _httpErrorCallback              = Nothing
+  , _flowId                         = Nothing
+  , _commitStrategy                 = defaultCommitStrategy
+  , _subscriptionStats              = Nothing
+  }
 
 -- | Producs a new configuration, with mandatory HTTP manager, default
 -- consumption parameters and HTTP request template.
@@ -84,8 +89,8 @@ newConfigIO = newConfig httpBackendIO
 
 -- | Produce a new configuration, with optional HTTP manager settings
 -- and mandatory HTTP request template.
-newConfigWithDedicatedManager ::
-  (MonadIO b, MonadMask b, MonadIO m)
+newConfigWithDedicatedManager
+  :: (MonadIO b, MonadMask b, MonadIO m)
   => ManagerSettings -- ^ Optional 'ManagerSettings'
   -> Request         -- ^ Request template for Nakadi requests
   -> m (Config b)    -- ^ Resulting Configuration
@@ -95,36 +100,26 @@ newConfigWithDedicatedManager mngrSettings request = do
 
 -- | Install an HTTP Manager in the provided configuration. If not
 -- set, HTTP requests will use a global default manager.
-setHttpManager
-  :: Manager
-  -> Config m
-  -> Config m
+setHttpManager :: Manager -> Config m -> Config m
 setHttpManager mngr = L.manager .~ Just mngr
 
 -- | Install a request modifier in the provided configuration. This
 -- can be used for e.g. including access tokens in HTTP requests to
 -- Nakadi.
-setRequestModifier ::
-  (Request -> m Request)
-  -> Config m
-  -> Config m
+setRequestModifier :: (Request -> m Request) -> Config m -> Config m
 setRequestModifier = (L.requestModifier .~)
 
 -- | Install a callback in the provided configuration to use in case
 -- of deserialization failures when consuming events.
-setDeserializationFailureCallback ::
-  (ByteString -> Text -> m ())
-  -> Config m
-  -> Config m
-setDeserializationFailureCallback cb = L.deserializationFailureCallback .~ Just cb
+setDeserializationFailureCallback
+  :: (ByteString -> Text -> m ()) -> Config m -> Config m
+setDeserializationFailureCallback cb =
+  L.deserializationFailureCallback .~ Just cb
 
 -- | Install a callback in the provided configuration which is used
 -- after having successfully established a streaming Nakadi
 -- connection.
-setStreamConnectCallback ::
-  StreamConnectCallback m
-  -> Config m
-  -> Config m
+setStreamConnectCallback :: StreamConnectCallback m -> Config m -> Config m
 setStreamConnectCallback cb = L.streamConnectCallback .~ Just cb
 
 -- | Install a callback in the provided configuration which is called
@@ -132,38 +127,23 @@ setStreamConnectCallback cb = L.streamConnectCallback .~ Just cb
 -- conditions by e.g. logging errors or updating metrics. Note that
 -- this callback is called synchronously, thus blocking in this
 -- callback delays potential retry attempts.
-setHttpErrorCallback ::
-  HttpErrorCallback m
-  -> Config m
-  -> Config m
+setHttpErrorCallback :: HttpErrorCallback m -> Config m -> Config m
 setHttpErrorCallback cb = L.httpErrorCallback .~ Just cb
 
 -- | Install a logger callback in the provided configuration.
-setLogFunc ::
-  LogFunc m
-  -> Config m
-  -> Config m
+setLogFunc :: LogFunc m -> Config m -> Config m
 setLogFunc logFunc = L.logFunc .~ Just logFunc
 
 -- | Set a custom retry policy in the provided configuration.
-setRetryPolicy ::
-  RetryPolicyM IO
-  -> Config m
-  -> Config m
+setRetryPolicy :: RetryPolicyM IO -> Config m -> Config m
 setRetryPolicy = (L.retryPolicy .~)
 
 -- | Set flow ID in the provided configuration.
-setFlowId
-  :: FlowId
-  -> Config m
-  -> Config m
+setFlowId :: FlowId -> Config m -> Config m
 setFlowId flowId = L.flowId .~ Just flowId
 
 -- | Set flow ID in the provided configuration.
-setCommitStrategy
-  :: CommitStrategy
-  -> Config m
-  -> Config m
+setCommitStrategy :: CommitStrategy -> Config m -> Config m
 setCommitStrategy = (L.commitStrategy .~)
 
 -- | Set maximum number of uncommitted events in the provided value of
@@ -192,3 +172,7 @@ setStreamTimeout n params = params & L.streamTimeout .~ Just n
 -- parameters.
 setStreamKeepAliveLimit :: Int32 -> ConsumeParameters -> ConsumeParameters
 setStreamKeepAliveLimit n params = params & L.streamKeepAliveLimit .~ Just n
+
+setShowTimeLag :: Bool -> Config m -> Config m
+setShowTimeLag flag =
+  L.subscriptionStats ?~ SubscriptionStatsConf {_showTimeLag = flag}

--- a/src/Network/Nakadi/Internal/Lenses.hs
+++ b/src/Network/Nakadi/Internal/Lenses.hs
@@ -33,6 +33,7 @@ import           Network.Nakadi.Internal.Types.Config
 import           Network.Nakadi.Internal.Types.Service
 
 makeNakadiLenses ''Config
+makeNakadiLenses ''SubscriptionStatsConf
 makeNakadiLenses ''HttpBackend
 makeNakadiLenses ''Cursor
 makeNakadiLenses ''DataChangeEvent
@@ -41,6 +42,7 @@ makeNakadiLenses ''SubscriptionEventStreamBatch
 makeNakadiLenses ''EventMetadata
 makeNakadiLenses ''EventMetadataEnriched
 makeNakadiLenses ''Partition
+makeNakadiLenses ''PartitionStat
 makeNakadiLenses ''CursorDistanceQuery
 makeNakadiLenses ''CursorDistanceResult
 makeNakadiLenses ''Timestamp

--- a/src/Network/Nakadi/Internal/Lenses.hs
+++ b/src/Network/Nakadi/Internal/Lenses.hs
@@ -24,9 +24,9 @@ module Network.Nakadi.Internal.Lenses where
 import           Network.Nakadi.Internal.Prelude
 
 import           Control.Lens
-import           Data.Text                             (Text)
+import           Data.Text                      ( Text )
 import           Data.Time.Clock
-import           Data.UUID                             (UUID)
+import           Data.UUID                      ( UUID )
 import           Network.Nakadi.Internal.TH
 
 import           Network.Nakadi.Internal.Types.Config
@@ -50,7 +50,7 @@ makeNakadiLenses ''EventType
 makeNakadiLenses ''EventTypeSchemasResponse
 makeNakadiLenses ''PaginationLink
 makeNakadiLenses ''PaginationLinks
-makeNakadiLenses ''SubscriptionEventTypeStatsResult
+makeNakadiLenses ''SubscriptionStats
 makeNakadiLenses ''ConsumeParameters
 makeNakadiLenses ''SubscriptionCursorCommit
 makeNakadiLenses ''SubscriptionCursor

--- a/src/Network/Nakadi/Internal/Types/Config.hs
+++ b/src/Network/Nakadi/Internal/Types/Config.hs
@@ -18,7 +18,7 @@ module Network.Nakadi.Internal.Types.Config where
 
 import           Conduit
 import           Control.Retry
-import qualified Data.ByteString.Lazy                        as LB
+import qualified Data.ByteString.Lazy          as LB
 import           Network.HTTP.Client
 import           Network.Nakadi.Internal.Prelude
 import           Network.Nakadi.Internal.Types.Logger
@@ -48,6 +48,7 @@ data Config m where
             , _httpErrorCallback              :: Maybe (HttpErrorCallback m)
             , _flowId                         :: Maybe FlowId
             , _commitStrategy                 :: CommitStrategy
+            , _subscriptionStats              :: Maybe SubscriptionStatsConf
             } -> Config m
 
 -- | ConsumeParameters
@@ -61,9 +62,12 @@ data ConsumeParameters = ConsumeParameters
   , _streamKeepAliveLimit :: Maybe Int32
   } deriving (Show, Eq, Ord)
 
-
 data HttpBackend b = HttpBackend
   { _httpLbs           :: Config b -> Request -> Maybe Manager -> b (Response LB.ByteString)
   , _httpResponseOpen  :: Config b -> Request -> Maybe Manager -> b (Response (ConduitM () ByteString b ()))
   , _httpResponseClose :: Response () -> b ()
+  }
+
+data SubscriptionStatsConf = SubscriptionStatsConf
+  { _showTimeLag :: Bool
   }

--- a/src/Network/Nakadi/Internal/Types/Service.hs
+++ b/src/Network/Nakadi/Internal/Types/Service.hs
@@ -26,11 +26,11 @@ import           Data.Aeson.TH
 import           Data.Aeson.Types
 import           Data.Hashable
 import           Data.String
-import qualified Data.Text                          as Text
+import qualified Data.Text                     as Text
 import           Data.Time
 import           Data.Time.ISO8601
 import           Data.UUID
-import           Data.Vector                        (Vector)
+import           Data.Vector                    ( Vector )
 import           GHC.Generics
 
 import           Network.Nakadi.Internal.Json
@@ -541,10 +541,12 @@ instance FromJSON PartitionState where
 -- | Type for per-partition statistics.
 
 data PartitionStat = PartitionStat
-  { _partition        :: PartitionName
-  , _state            :: PartitionState
-  , _unconsumedEvents :: Int64
-  , _streamId         :: StreamId
+  { _partition          :: PartitionName
+  , _state              :: PartitionState
+  , _unconsumedEvents   :: Int64
+  , _streamId           :: StreamId
+  , _consumerLagSeconds :: Maybe Int64
+  , _streamId           :: Maybe StreamId
   } deriving (Show, Eq, Ord, Generic)
 
 deriveJSON nakadiJsonOptions ''PartitionStat
@@ -558,15 +560,24 @@ data SubscriptionEventTypeStats = SubscriptionEventTypeStats
 
 deriveJSON nakadiJsonOptions ''SubscriptionEventTypeStats
 
--- | SubscriptionEventTypeStatsResult
+-- | Type modelling per-subscription statistics. Objects of this type are returned by
+-- requests to /subscriptions/SUBSCRIPTION-ID/stats.
 
-newtype SubscriptionEventTypeStatsResult = SubscriptionEventTypeStatsResult
+newtype SubscriptionStats = SubscriptionStats
   { _items :: [SubscriptionEventTypeStats]
   } deriving (Show, Eq, Ord, Generic)
 
-deriveJSON nakadiJsonOptions ''SubscriptionEventTypeStatsResult
+deriveJSON nakadiJsonOptions ''SubscriptionStats
 
--- | Type for the category of an 'EventType'.
+-- Retrieving of per-subscriptions statistics supports a single flag currently: @show_time_lag@. For future
+-- extendability, we provide a type for such parameters instead of simply encoding this as a boolean. This
+-- is then used by the high-level API calls `subscriptionStats`, while the low-level call `subscriptionStats'`
+-- simply expects the @show_time_lag@ boolean to be provided.
+
+data SubscriptionStatsParameter = ShowTimeLag
+  deriving (Show, Eq, Ord, Generic)
+
+--  | Type for the category of an 'EventType'.
 
 data EventTypeCategory = EventTypeCategoryUndefined
                        | EventTypeCategoryData

--- a/src/Network/Nakadi/Internal/Types/Service.hs
+++ b/src/Network/Nakadi/Internal/Types/Service.hs
@@ -543,10 +543,9 @@ instance FromJSON PartitionState where
 data PartitionStat = PartitionStat
   { _partition          :: PartitionName
   , _state              :: PartitionState
-  , _unconsumedEvents   :: Int64
-  , _streamId           :: StreamId
-  , _consumerLagSeconds :: Maybe Int64
+  , _unconsumedEvents   :: Maybe Int64
   , _streamId           :: Maybe StreamId
+  , _consumerLagSeconds :: Maybe Int64
   } deriving (Show, Eq, Ord, Generic)
 
 deriveJSON nakadiJsonOptions ''PartitionStat
@@ -568,14 +567,6 @@ newtype SubscriptionStats = SubscriptionStats
   } deriving (Show, Eq, Ord, Generic)
 
 deriveJSON nakadiJsonOptions ''SubscriptionStats
-
--- Retrieving of per-subscriptions statistics supports a single flag currently: @show_time_lag@. For future
--- extendability, we provide a type for such parameters instead of simply encoding this as a boolean. This
--- is then used by the high-level API calls `subscriptionStats`, while the low-level call `subscriptionStats'`
--- simply expects the @show_time_lag@ boolean to be provided.
-
-data SubscriptionStatsParameter = ShowTimeLag
-  deriving (Show, Eq, Ord, Generic)
 
 --  | Type for the category of an 'EventType'.
 

--- a/src/Network/Nakadi/Internal/Util.hs
+++ b/src/Network/Nakadi/Internal/Util.hs
@@ -18,38 +18,39 @@ module Network.Nakadi.Internal.Util
   , decodeThrow
   , sequenceSnd
   , extractQueryParametersFromPath
-  ) where
+  , encodeStrict
+  )
+where
 
 import           Network.Nakadi.Internal.Prelude
 
-import           Conduit                         hiding (throwM)
+import           Conduit                 hiding ( throwM )
 import           Data.Aeson
-import qualified Data.ByteString.Lazy            as ByteString.Lazy
-import qualified Data.Text                       as Text
+import qualified Data.ByteString.Lazy          as ByteString.Lazy
+import qualified Data.Text                     as Text
 import           Network.HTTP.Simple
 
 import           Network.Nakadi.Internal.Types
 
-conduitDrainToLazyByteString ::
-  Monad b
-  => ConduitM () ByteString b ()
-  -> b ByteString.Lazy.ByteString
-conduitDrainToLazyByteString conduit =
-  runConduit $ conduit .| sinkLazy
+conduitDrainToLazyByteString
+  :: Monad b => ConduitM () ByteString b () -> b ByteString.Lazy.ByteString
+conduitDrainToLazyByteString conduit = runConduit $ conduit .| sinkLazy
 
-decodeThrow
-  :: (FromJSON a, MonadThrow m)
-  => ByteString.Lazy.ByteString
-  -> m a
+decodeThrow :: (FromJSON a, MonadThrow m) => ByteString.Lazy.ByteString -> m a
 decodeThrow s = case eitherDecode' s of
-  Right a  -> pure a
-  Left err -> throwM (DeserializationFailure (ByteString.Lazy.toStrict s) (Text.pack err))
+  Right a -> pure a
+  Left err ->
+    throwM (DeserializationFailure (ByteString.Lazy.toStrict s) (Text.pack err))
 
 sequenceSnd :: Functor f => (a, f b) -> f (a, b)
-sequenceSnd (a, fb) = (a,) <$> fb
+sequenceSnd (a, fb) = (a, ) <$> fb
 
 extractQueryParametersFromPath :: String -> Maybe [(ByteString, ByteString)]
 extractQueryParametersFromPath path =
   case parseRequest ("http://localhost" <> path) of
-    Just req -> Just . catMaybes . map sequenceSnd . getRequestQueryString $ req
+    Just req ->
+      Just . catMaybes . map sequenceSnd . getRequestQueryString $ req
     Nothing -> Nothing
+
+encodeStrict :: ToJSON a => a -> ByteString
+encodeStrict = ByteString.Lazy.toStrict . encode

--- a/src/Network/Nakadi/Subscriptions/Stats.hs
+++ b/src/Network/Nakadi/Subscriptions/Stats.hs
@@ -57,7 +57,7 @@ subscriptionStats' subscriptionId showTimeLag = httpJsonBody
 subscriptionStats
   :: MonadNakadi b m
   => SubscriptionId                        -- ^ Subscription ID
-  -> [SubscriptionStatsParameter]
+  -> [SubscriptionStatsParameter]          -- ^ Optional parameters, currently only `ShowTimeLag` is supported.
   -> m (Map EventTypeName [PartitionStat]) -- ^ Subscription
                                            -- Statistics as a 'Map'.
 subscriptionStats subscriptionId parameters = do

--- a/src/Network/Nakadi/Subscriptions/Stats.hs
+++ b/src/Network/Nakadi/Subscriptions/Stats.hs
@@ -36,7 +36,7 @@ path :: SubscriptionId -> ByteString
 path subscriptionId =
   "/subscriptions/" <> subscriptionIdToByteString subscriptionId <> "/stats"
 
--- | @GET@ to @\/subscriptions\/SUBSCRIPTION\/cursors@. Low level
+-- | @GET@ to @\/subscriptions\/SUBSCRIPTION\/stats@. Low level
 -- interface for Subscriptions Statistics retrieval.
 subscriptionStats'
   :: MonadNakadi b m
@@ -52,7 +52,7 @@ subscriptionStats' subscriptionId showTimeLag = httpJsonBody
   )
   where queryParameters = [("show_time_lag", encodeStrict (Bool showTimeLag))]
 
--- | @GET@ to @\/subscriptions\/SUBSCRIPTION\/cursors@. High level
+-- | @GET@ to @\/subscriptions\/SUBSCRIPTION\/stats@. High level
 -- interface for Subscription Statistics retrieval.
 subscriptionStats
   :: MonadNakadi b m

--- a/src/Network/Nakadi/Subscriptions/Stats.hs
+++ b/src/Network/Nakadi/Subscriptions/Stats.hs
@@ -18,39 +18,52 @@ API.
 module Network.Nakadi.Subscriptions.Stats
   ( subscriptionStats'
   , subscriptionStats
-  ) where
+  )
+where
 
 import           Network.Nakadi.Internal.Prelude
 
 import           Control.Lens
-import qualified Data.Map.Strict                     as Map
+import           Data.Aeson
+import qualified Data.Map.Strict               as Map
 import           Network.Nakadi.Internal.Conversions
 import           Network.Nakadi.Internal.Http
-import qualified Network.Nakadi.Internal.Lenses      as L
+import qualified Network.Nakadi.Internal.Lenses
+                                               as L
+import           Network.Nakadi.Internal.Util
 
 path :: SubscriptionId -> ByteString
 path subscriptionId =
-  "/subscriptions/"
-  <> subscriptionIdToByteString subscriptionId
-  <> "/cursors"
+  "/subscriptions/" <> subscriptionIdToByteString subscriptionId <> "/stats"
 
 -- | @GET@ to @\/subscriptions\/SUBSCRIPTION\/cursors@. Low level
 -- interface for Subscriptions Statistics retrieval.
-subscriptionStats' ::
-  MonadNakadi b m
-  => SubscriptionId                     -- ^ Subscription ID
-  -> m SubscriptionEventTypeStatsResult -- ^ Subscription Statistics
-subscriptionStats' subscriptionId =
-  httpJsonBody ok200 [(status404, errorSubscriptionNotFound)]
-  (setRequestMethod "GET" . setRequestPath (path subscriptionId))
+subscriptionStats'
+  :: MonadNakadi b m
+  => SubscriptionId      -- ^ Subscription ID
+  -> Bool                -- ^ Whether to show time lag.
+  -> m SubscriptionStats -- ^ Subscription Statistics
+subscriptionStats' subscriptionId showTimeLag = httpJsonBody
+  ok200
+  [(status404, errorSubscriptionNotFound)]
+  ( setRequestMethod "GET"
+  . setRequestPath (path subscriptionId)
+  . setRequestQueryParameters queryParameters
+  )
+  where queryParameters = [("show_time_lag", encodeStrict (Bool showTimeLag))]
 
 -- | @GET@ to @\/subscriptions\/SUBSCRIPTION\/cursors@. High level
 -- interface for Subscription Statistics retrieval.
-subscriptionStats ::
-  MonadNakadi b m
+subscriptionStats
+  :: MonadNakadi b m
   => SubscriptionId                        -- ^ Subscription ID
+  -> [SubscriptionStatsParameter]
   -> m (Map EventTypeName [PartitionStat]) -- ^ Subscription
                                            -- Statistics as a 'Map'.
-subscriptionStats subscriptionId = do
-  items <- subscriptionStats' subscriptionId <&> view L.items
-  return . Map.fromList . map (\SubscriptionEventTypeStats { .. } -> (_eventType, _partitions)) $ items
+subscriptionStats subscriptionId parameters = do
+  items <- subscriptionStats' subscriptionId showTimeLag <&> view L.items
+  return
+    . Map.fromList
+    . map (\SubscriptionEventTypeStats {..} -> (_eventType, _partitions))
+    $ items
+  where showTimeLag = ShowTimeLag `elem` parameters

--- a/src/Network/Nakadi/Types/Service.hs
+++ b/src/Network/Nakadi/Types/Service.hs
@@ -55,7 +55,6 @@ module Network.Nakadi.Types.Service
   , PartitionStat(..)
   , SubscriptionEventTypeStats(..)
   , SubscriptionStats(..)
-  , SubscriptionStatsParameter(..)
   , EventTypeCategory(..)
   , PartitionStrategy(..)
   , EnrichmentStrategy(..)

--- a/src/Network/Nakadi/Types/Service.hs
+++ b/src/Network/Nakadi/Types/Service.hs
@@ -54,7 +54,8 @@ module Network.Nakadi.Types.Service
   , PartitionState(..)
   , PartitionStat(..)
   , SubscriptionEventTypeStats(..)
-  , SubscriptionEventTypeStatsResult(..)
+  , SubscriptionStats(..)
+  , SubscriptionStatsParameter(..)
   , EventTypeCategory(..)
   , PartitionStrategy(..)
   , EnrichmentStrategy(..)
@@ -68,6 +69,7 @@ module Network.Nakadi.Types.Service
   , EventMetadataEnriched(..)
   , EventTypeStatistics(..)
   , EventTypeOptions(..)
-  ) where
+  )
+where
 
 import           Network.Nakadi.Internal.Types.Service

--- a/tests/Network/Nakadi/Subscriptions/Stats/Test.hs
+++ b/tests/Network/Nakadi/Subscriptions/Stats/Test.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
+-- This test tests the subscription statistics API.
+
+module Network.Nakadi.Subscriptions.Stats.Test where
+
+import           ClassyPrelude
+
+import           Control.Lens
+import           Data.Aeson
+import           Data.Maybe                     ( fromJust )
+import           Network.Nakadi
+import qualified Network.Nakadi.Lenses         as L
+import           Network.Nakadi.Tests.Common
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Control.Concurrent
+
+testSubscriptionsStats :: Config App -> TestTree
+testSubscriptionsStats conf = testGroup
+  "Stats"
+  [ testCase "SubscriptionStats/WithTimeLag"
+    $ testSubscriptionStatsWithTimeLag conf
+  , testCase "SubscriptionStats/WithoutTimeLag"
+    $ testSubscriptionStatsWithoutTimeLag conf
+  ]
+
+produceSubscriptionStats :: Config App -> IO (Map EventTypeName [PartitionStat])
+produceSubscriptionStats conf =
+  runApp
+    $ runNakadiT conf
+    $ bracket before after
+    $ \subscriptionId -> do
+    -- Note: Apparently we have to consume the subscription first in order to enable
+    -- tracking of unconsumed events and time lag.
+        void $ timeout (2 * 10 ^ (6 :: Int)) $ subscriptionProcess
+          Nothing
+          subscriptionId
+          (\(_batch :: SubscriptionEventStreamBatch (DataChangeEvent Value)) ->
+            pure ()
+          )
+        events <- replicateM 10 (genMyDataChangeEventIdx 1)
+        eventsPublish myEventTypeName events
+        liftIO $ threadDelay (1 * 10 ^ (6 :: Int))
+        subscriptionStats subscriptionId
+
+testSubscriptionStatsWithoutTimeLag :: Config App -> Assertion
+testSubscriptionStatsWithoutTimeLag conf = do
+  stats <- produceSubscriptionStats (setShowTimeLag False conf)
+  let withTimeLags =
+        stats & toList & concat & map (^. L.consumerLagSeconds) & filter isJust
+  liftIO $ [] @=? withTimeLags
+
+testSubscriptionStatsWithTimeLag :: Config App -> Assertion
+testSubscriptionStatsWithTimeLag conf = do
+  stats <- produceSubscriptionStats (setShowTimeLag True conf)
+  let withoutTimeLags =
+        stats
+          & toList
+          & concat
+          & map (^. L.consumerLagSeconds)
+          & filter isNothing
+  liftIO $ [] @=? withoutTimeLags
+
+before :: (MonadUnliftIO m, MonadNakadi App m) => m SubscriptionId
+before = do
+  recreateEvent myEventType
+  subscription <- subscriptionCreate Subscription
+    { _id                = Nothing
+    , _owningApplication = "test-suite"
+    , _eventTypes        = [myEventTypeName]
+    , _consumerGroup     = Nothing
+    , _createdAt         = Nothing
+    , _readFrom          = Just SubscriptionPositionBegin
+    , _initialCursors    = Nothing
+    }
+  pure . fromJust $ subscription ^. L.id
+
+after :: (MonadUnliftIO m, MonadNakadi App m) => SubscriptionId -> m ()
+after subscriptionId = do
+  subscriptionDelete subscriptionId
+  eventTypeDelete myEventTypeName `catch` (ignoreExnNotFound ())


### PR DESCRIPTION
This fixes the per-subscription statistics retrieval and implements support for the new `show_time_lag` parameter of the Nakadi API.

The statistics retrieval never worked before, thus I felt free to improve the general API in this regard.

In particular I have renamed the type `SubscriptionEventTypeStatsResult` to `SubscriptionStats` — the Nakadi Swagger does not contain a specific name for this object type.

There is some reformatting being done by brittany, sorry for the noise.
I have tested the API call manually, but a test should be added.

I wouldn't mind merging this right away, though.
