### PR TITLE
Separate subscription types

### DIFF
--- a/brittany.yaml
+++ b/brittany.yaml
@@ -1,0 +1,57 @@
+conf_debug:
+  dconf_roundtrip_exactprint_only: false
+  dconf_dump_bridoc_simpl_par: false
+  dconf_dump_ast_unknown: false
+  dconf_dump_bridoc_simpl_floating: false
+  dconf_dump_config: false
+  dconf_dump_bridoc_raw: false
+  dconf_dump_bridoc_final: false
+  dconf_dump_bridoc_simpl_alt: false
+  dconf_dump_bridoc_simpl_indent: false
+  dconf_dump_annotations: false
+  dconf_dump_bridoc_simpl_columns: false
+  dconf_dump_ast_full: false
+conf_forward:
+  options_ghc:
+  - -XLambdaCase
+  - -XMultiWayIf
+  - -XGADTs
+  - -XPatternGuards
+  - -XViewPatterns
+  - -XRecursiveDo
+  - -XTupleSections
+  - -XExplicitForAll
+  - -XImplicitParams
+  - -XQuasiQuotes
+  - -XTemplateHaskell
+  - -XBangPatterns
+conf_errorHandling:
+  econf_ExactPrintFallback: ExactPrintFallbackModeInline
+  econf_Werror: false
+  econf_omit_output_valid_check: false
+  econf_produceOutputOnErrors: false
+conf_preprocessor:
+  ppconf_CPPMode: CPPModeAbort
+  ppconf_hackAroundIncludes: false
+conf_obfuscate: false
+conf_roundtrip_exactprint_only: false
+conf_version: 1
+conf_layout:
+  lconfig_reformatModulePreamble: true
+  lconfig_altChooser:
+    tag: AltChooserBoundedSearch
+    contents: 3
+  lconfig_allowSingleLineExportList: false
+  lconfig_importColumn: 50
+  lconfig_hangingTypeSignature: false
+  lconfig_importAsColumn: 50
+  lconfig_alignmentLimit: 30
+  lconfig_indentListSpecial: true
+  lconfig_indentAmount: 2
+  lconfig_alignmentBreakOnMultiline: true
+  lconfig_cols: 100
+  lconfig_indentPolicy: IndentPolicyFree
+  lconfig_indentWhereSpecial: true
+  lconfig_columnAlignMode:
+    tag: ColumnAlignModeMajority
+    contents: 0.7

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: nakadi-client
-version: '0.5.2.0'
+version: '0.6.0.0'
 synopsis: Client library for the Nakadi Event Broker
 description: This package implements a client library for interacting
              with the Nakadi event broker system developed by Zalando.

--- a/package.yaml
+++ b/package.yaml
@@ -132,3 +132,4 @@ tests:
     - unliftio
     - monad-logger
     - fast-logger
+    - aeson-qq >= 0.8.2 && < 0.9

--- a/src/Network/Nakadi/Internal/Lenses.hs
+++ b/src/Network/Nakadi/Internal/Lenses.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Network.Nakadi.Lenses
 Description : Nakadi Client Library Lenses (Internal)
-Copyright   : (c) Moritz Schulte 2017, 2018
+Copyright   : (c) Moritz Clasmeier 2017, 2018
 License     : BSD3
 Maintainer  : mtesseract@silverratio.net
 Stability   : experimental
@@ -59,6 +59,7 @@ makeNakadiLenses ''SubscriptionCursor
 makeNakadiLenses ''CursorCommit
 makeNakadiLenses ''SubscriptionsListResponse
 makeNakadiLenses ''Subscription
+makeNakadiLenses ''SubscriptionRequest
 
 instance HasNakadiId StreamId Text where
   id f (StreamId a) = StreamId <$> f a

--- a/src/Network/Nakadi/Internal/Types/Service.hs
+++ b/src/Network/Nakadi/Internal/Types/Service.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Network.Nakadi.Internal.Types.Service
 Description : Nakadi Client Service Types (Internal)
-Copyright   : (c) Moritz Schulte 2017, 2018
+Copyright   : (c) Moritz Clasmeier 2017, 2018
 License     : BSD3
 Maintainer  : mtesseract@silverratio.net
 Stability   : experimental
@@ -16,6 +16,7 @@ Types modelling the Nakadi Service API.
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE RecordWildCards       #-}
 
 module Network.Nakadi.Internal.Types.Service where
 
@@ -25,6 +26,7 @@ import           Data.Aeson
 import           Data.Aeson.TH
 import           Data.Aeson.Types
 import           Data.Hashable
+import qualified Data.HashMap.Strict           as HashMap
 import           Data.String
 import qualified Data.Text                     as Text
 import           Data.Time
@@ -279,39 +281,126 @@ newtype CursorDistanceResult = CursorDistanceResult
 
 deriveJSON nakadiJsonOptions ''CursorDistanceResult
 
--- | Type for subscription positions.
+-- | This type models the "read_from" field contained in subscription objects.
+
+data SubscriptionReadFrom = SubscriptionReadFromBegin
+                          | SubscriptionReadFromEnd
+                          | SubscriptionReadFromCursors
+                          deriving (Show, Eq, Ord, Generic, Hashable)
+
+instance ToJSON SubscriptionReadFrom where
+  toJSON = \case
+    SubscriptionReadFromBegin   -> "begin"
+    SubscriptionReadFromEnd     -> "end"
+    SubscriptionReadFromCursors -> "cursors"
+
+instance FromJSON SubscriptionReadFrom where
+  parseJSON = \case
+    "begin"   -> return SubscriptionReadFromBegin
+    "end"     -> return SubscriptionReadFromEnd
+    "cursors" -> return SubscriptionReadFromCursors
+    invalid   -> typeMismatch "SubscriptionReadFrom" invalid
+
+-- | Type modelling a subscription position.
 
 data SubscriptionPosition = SubscriptionPositionBegin
                           | SubscriptionPositionEnd
-                          | SubscriptionPositionCursors
+                          | SubscriptionPositionCursors [SubscriptionCursorWithoutToken]
                           deriving (Show, Eq, Ord, Generic, Hashable)
 
+-- | Internal helper function for converting a 'SubscriptionPosition' into a
+-- JSON Object (not a JSON Value). Removes the need for partial pattern matching later.
+subscriptionPositionToObject :: SubscriptionPosition -> Object
+subscriptionPositionToObject = \case
+    SubscriptionPositionBegin ->
+      HashMap.fromList [("read_from", toJSON SubscriptionReadFromBegin)]
+    SubscriptionPositionEnd ->
+      HashMap.fromList [("read_from", toJSON SubscriptionReadFromEnd)]
+    SubscriptionPositionCursors cursors ->
+      HashMap.fromList [("read_from", toJSON SubscriptionReadFromCursors)
+                       ,("cursors",   toJSON cursors)]
+
 instance ToJSON SubscriptionPosition where
-  toJSON pos = case pos of
-                 SubscriptionPositionBegin   -> "begin"
-                 SubscriptionPositionEnd     -> "end"
-                 SubscriptionPositionCursors -> "cursors"
+  toJSON = Object . subscriptionPositionToObject
 
 instance FromJSON SubscriptionPosition where
-  parseJSON pos = case pos of
-                    "begin"   -> return SubscriptionPositionBegin
-                    "end"     -> return SubscriptionPositionEnd
-                    "cursors" -> return SubscriptionPositionCursors
-                    invalid   -> typeMismatch "SubscriptionPosition" invalid
+  parseJSON = withObject "SubscriptionPosition" $ \obj -> do
+    readFrom <- obj .: "read_from" >>= parseJSON
+    case readFrom of
+      SubscriptionReadFromBegin ->
+        pure SubscriptionPositionBegin
+      SubscriptionReadFromEnd ->
+        pure SubscriptionPositionEnd
+      SubscriptionReadFromCursors ->
+        SubscriptionPositionCursors <$> obj .: "cursors"
 
--- | Type for a Subscription.
+-- | This type models the value describing the use case of a subscription.
+-- In general this is an additional identifier used to differ subscriptions
+-- having the same owning application and event types.
+data ConsumerGroup = ConsumerGroup { unConsumerGroup :: Text }
+  deriving (Eq, Ord, Show, Generic, Hashable)
 
+instance ToJSON ConsumerGroup where
+  toJSON = String . unConsumerGroup
+
+instance FromJSON ConsumerGroup where
+  parseJSON = parseString "ConsumerGroup" ConsumerGroup
+
+-- | Type for a Subscription which has already been created.
 data Subscription = Subscription
-  { _id                :: Maybe SubscriptionId
-  , _owningApplication :: ApplicationName
-  , _eventTypes        :: [EventTypeName]
-  , _consumerGroup     :: Maybe Text
-  , _createdAt         :: Maybe Timestamp
-  , _readFrom          :: Maybe SubscriptionPosition
-  , _initialCursors    :: Maybe [SubscriptionCursorWithoutToken]
+  { _id                   :: SubscriptionId
+  , _owningApplication    :: ApplicationName
+  , _eventTypes           :: [EventTypeName]
+  , _consumerGroup        :: ConsumerGroup
+  , _createdAt            :: Timestamp
+  , _subscriptionPosition :: SubscriptionPosition
   } deriving (Show, Eq, Ord, Generic, Hashable)
 
-deriveJSON nakadiJsonOptions ''Subscription
+instance FromJSON Subscription where
+  parseJSON = withObject "Subscription" $ \obj ->
+    Subscription <$> obj .: "id"
+                 <*> obj .: "owning_application"
+                 <*> obj .: "event_types"
+                 <*> obj .: "consumer_group"
+                 <*> obj .: "created_at"
+                 <*> parseJSON (Object obj)
+
+instance ToJSON Subscription where
+  toJSON Subscription {..} =
+      let obj = HashMap.fromList [ ("id",                 toJSON _id)
+                                 , ("owning_application", toJSON _owningApplication)
+                                 , ("event_types",        toJSON _eventTypes)
+                                 , ("consumer_group",     toJSON _consumerGroup)
+                                 , ("created_at",         toJSON _createdAt) ]
+                <> subscriptionPositionToObject _subscriptionPosition
+      in Object obj
+
+-- | Type for a Subscription which is to be created.
+data SubscriptionRequest = SubscriptionRequest
+  { _owningApplication    :: ApplicationName
+  , _eventTypes           :: [EventTypeName]
+  , _consumerGroup        :: Maybe ConsumerGroup
+  , _subscriptionPosition :: Maybe SubscriptionPosition
+  } deriving (Show, Eq, Ord, Generic, Hashable)
+
+instance FromJSON SubscriptionRequest where
+  parseJSON = withObject "SubscriptionRequest" $ \obj ->
+    SubscriptionRequest <$> obj .: "owning_application"
+                        <*> obj .: "event_types"
+                        <*> obj .:? "consumer_group"
+                        <*> parseJSON (Object obj)
+
+instance ToJSON SubscriptionRequest where
+  toJSON SubscriptionRequest {..} =
+    let obj = subscriptionPositionToObject (fromMaybe SubscriptionPositionEnd _subscriptionPosition)
+              <> HashMap.fromList [ ("owning_application", toJSON _owningApplication)
+                                  , ("event_types",        toJSON _eventTypes) ]
+              <> case _consumerGroup of 
+                  Just consumerGroup ->
+                    HashMap.fromList [ ("consumer_group", toJSON consumerGroup) ]
+                  Nothing ->
+                    HashMap.empty
+    in Object obj
 
 -- | Type for publishing status.
 data PublishingStatus = PublishingStatusSubmitted

--- a/src/Network/Nakadi/Internal/Types/Util.hs
+++ b/src/Network/Nakadi/Internal/Types/Util.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Network.Nakadi.Internal.Types.Util
 Description : Nakadi Client Utilities for Types (Internal)
-Copyright   : (c) Moritz Schulte 2017
+Copyright   : (c) Moritz Clasmeier 2017, 2018
 License     : BSD3
 Maintainer  : mtesseract@silverratio.net
 Stability   : experimental
@@ -14,9 +14,10 @@ module Network.Nakadi.Internal.Types.Util where
 
 import           Data.Aeson
 import           Data.Aeson.Types
+import           Data.Text                      ( Text )
 import           Data.Maybe
-import           Data.Scientific  (toBoundedInteger)
-import qualified Data.Text        as Text
+import           Data.Scientific                ( toBoundedInteger )
+import qualified Data.Text                     as Text
 import           Data.UUID
 import           Prelude
 
@@ -26,14 +27,18 @@ makeFieldRenamer fieldMap field = fromMaybe field (lookup field fieldMap)
 
 parseUUID :: String -> (UUID -> a) -> Value -> Parser a
 parseUUID label constructor val@(String valS) =
-    case Data.UUID.fromString (Text.unpack valS) of
-      Just uuid -> return (constructor uuid)
-      Nothing   -> typeMismatch label val
+  case Data.UUID.fromString (Text.unpack valS) of
+    Just uuid -> return (constructor uuid)
+    Nothing   -> typeMismatch label val
 parseUUID label _ val = typeMismatch label val
 
-parseInteger :: (Integral i, Bounded i) => String -> (i -> a) -> Value -> Parser a
-parseInteger label constructor val@(Number n) =
-  case toBoundedInteger n of
-    Just i  -> return $ constructor i
-    Nothing -> typeMismatch label val
+parseInteger
+  :: (Integral i, Bounded i) => String -> (i -> a) -> Value -> Parser a
+parseInteger label constructor val@(Number n) = case toBoundedInteger n of
+  Just i  -> return $ constructor i
+  Nothing -> typeMismatch label val
 parseInteger label _ val = typeMismatch label val
+
+parseString :: String -> (Text -> a) -> Value -> Parser a
+parseString _label ctor (String s) = pure (ctor s)
+parseString label  _    val        = typeMismatch label val

--- a/src/Network/Nakadi/Subscriptions.hs
+++ b/src/Network/Nakadi/Subscriptions.hs
@@ -24,16 +24,18 @@ module Network.Nakadi.Subscriptions
   , subscriptionsList'
   , subscriptionsSource
   , subscriptionsList
-  ) where
+  )
+where
 
 import           Network.Nakadi.Internal.Prelude
 
 import           Conduit
-import qualified Control.Exception.Safe                    as Safe
+import qualified Control.Exception.Safe        as Safe
 import           Control.Lens
-import qualified Data.Text                                 as Text
+import qualified Data.Text                     as Text
 import           Network.Nakadi.Internal.Http
-import qualified Network.Nakadi.Internal.Lenses            as L
+import qualified Network.Nakadi.Internal.Lenses
+                                               as L
 import           Network.Nakadi.Internal.Util
 import           Network.Nakadi.Subscriptions.Cursors
 import           Network.Nakadi.Subscriptions.Events
@@ -45,93 +47,104 @@ path = "/subscriptions"
 
 -- | @POST@ to @\/subscriptions@. Creates a new subscription. Low
 -- level interface.
-subscriptionCreate' ::
-  MonadNakadi b m
-  => Subscription
-  -> m Subscription
-subscriptionCreate' subscription =
-  httpJsonBody status201 [(ok200, errorSubscriptionExistsAlready)]
-  (setRequestMethod "POST"
-   . setRequestPath path
-   . setRequestBodyJSON subscription)
+subscriptionCreate' :: MonadNakadi b m => SubscriptionRequest -> m Subscription
+subscriptionCreate' subscription = httpJsonBody
+  status201
+  [(ok200, errorSubscriptionExistsAlready)]
+  ( setRequestMethod "POST"
+  . setRequestPath path
+  . setRequestBodyJSON subscription
+  )
 
 -- | @POST@ to @\/subscriptions@. Creates a new subscription. Does not
 -- fail if the requested subscription does already exist.
-subscriptionCreate ::
-  (MonadNakadi b m, MonadCatch m)
-  => Subscription
-  -> m Subscription
-subscriptionCreate subscription = do
-  Safe.catchJust exceptionPredicate (subscriptionCreate' subscription) return
-
-  where exceptionPredicate (SubscriptionExistsAlready s) = Just s
-        exceptionPredicate _                             = Nothing
+subscriptionCreate
+  :: (MonadNakadi b m, MonadCatch m) => SubscriptionRequest -> m Subscription
+subscriptionCreate subscription = Safe.catchJust
+  exceptionPredicate
+  (subscriptionCreate' subscription)
+  return
+ where
+  exceptionPredicate (SubscriptionExistsAlready s) = Just s
+  exceptionPredicate _                             = Nothing
 
 -- | @GET@ to @\/subscriptions@. Internal low-level interface.
-subscriptionsGet ::
-  MonadNakadi b m
+subscriptionsGet
+  :: MonadNakadi b m
   => [(ByteString, ByteString)]
   -> m SubscriptionsListResponse
-subscriptionsGet queryParameters =
-  httpJsonBody ok200 []
-  (setRequestMethod "GET"
-   . setRequestPath path
-   . setRequestQueryParameters queryParameters)
+subscriptionsGet queryParameters = httpJsonBody
+  ok200
+  []
+  ( setRequestMethod "GET"
+  . setRequestPath path
+  . setRequestQueryParameters queryParameters
+  )
 
-buildQueryParameters :: Maybe ApplicationName
-                     -> Maybe [EventTypeName]
-                     -> Maybe Limit
-                     -> Maybe Offset
-                     -> [(ByteString, ByteString)]
-buildQueryParameters maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset =
-  catMaybes $
-  [ ("owning_application",) . encodeUtf8 . unApplicationName <$> maybeOwningApp
-  , ("limit",) . encodeUtf8 . tshow <$> maybeLimit
-  , ("offset",) . encodeUtf8 . tshow <$> maybeOffset ]
-  ++ case maybeEventTypeNames of
-       Just eventTypeNames -> map (Just . ("event_type",) . encodeUtf8 . unEventTypeName) eventTypeNames
-       Nothing -> []
+buildQueryParameters
+  :: Maybe ApplicationName
+  -> Maybe [EventTypeName]
+  -> Maybe Limit
+  -> Maybe Offset
+  -> [(ByteString, ByteString)]
+buildQueryParameters maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset
+  = catMaybes
+    $  [ ("owning_application", )
+       .   encodeUtf8
+       .   unApplicationName
+       <$> maybeOwningApp
+       , ("limit", ) . encodeUtf8 . tshow <$> maybeLimit
+       , ("offset", ) . encodeUtf8 . tshow <$> maybeOffset
+       ]
+    ++ case maybeEventTypeNames of
+         Just eventTypeNames -> map
+           (Just . ("event_type", ) . encodeUtf8 . unEventTypeName)
+           eventTypeNames
+         Nothing -> []
 
 -- | @GET@ to @\/subscriptions@. Retrieves all subscriptions matching
 -- the provided filter criteria. Low-level interface using pagination.
-subscriptionsList' ::
-  (MonadNakadi b m)
+subscriptionsList'
+  :: (MonadNakadi b m)
   => Maybe ApplicationName
   -> Maybe [EventTypeName]
   -> Maybe Limit
   -> Maybe Offset
   -> m SubscriptionsListResponse
-subscriptionsList' maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset = do
+subscriptionsList' maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset =
   subscriptionsGet queryParameters
-  where queryParameters =
-          buildQueryParameters maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset
+ where
+  queryParameters = buildQueryParameters maybeOwningApp
+                                         maybeEventTypeNames
+                                         maybeLimit
+                                         maybeOffset
 
 -- | @GET@ to @\/subscriptions@. Retrieves all subscriptions matching
 -- the provided filter criteria. High-level Conduit interface.
-subscriptionsSource :: ( MonadNakadi b m)
-                    => Maybe ApplicationName
-                    -> Maybe [EventTypeName]
-                    -> m (ConduitM () [Subscription] m ())
-subscriptionsSource maybeOwningApp maybeEventTypeNames =
-  pure $ nextPage initialQueryParameters
+subscriptionsSource
+  :: (MonadNakadi b m)
+  => Maybe ApplicationName
+  -> Maybe [EventTypeName]
+  -> m (ConduitM () [Subscription] m ())
+subscriptionsSource maybeOwningApp maybeEventTypeNames = pure
+  $ nextPage initialQueryParameters
+ where
+  nextPage queryParameters = do
+    resp <- lift $ subscriptionsGet queryParameters
+    yield (resp ^. L.items)
+    let maybeNextPath =
+          Text.unpack . (view L.href) <$> (resp ^. L.links . L.next)
+    case maybeNextPath >>= extractQueryParametersFromPath of
+      Just nextQueryParameters -> nextPage nextQueryParameters
+      Nothing                  -> return ()
 
-  where nextPage queryParameters = do
-          resp <- lift $ subscriptionsGet queryParameters
-          yield (resp^.L.items)
-          let maybeNextPath = Text.unpack . (view L.href) <$> (resp^.L.links.L.next)
-          case maybeNextPath >>= extractQueryParametersFromPath  of
-            Just nextQueryParameters -> do
-              nextPage nextQueryParameters
-            Nothing ->
-              return ()
-
-        initialQueryParameters =
-          buildQueryParameters maybeOwningApp maybeEventTypeNames Nothing Nothing
+  initialQueryParameters =
+    buildQueryParameters maybeOwningApp maybeEventTypeNames Nothing Nothing
 
 -- | @GET@ to @\/subscriptions@. Retrieves all subscriptions matching
 -- the provided filter criteria. High-level list interface.
-subscriptionsList ::
-  MonadNakadi b m
+subscriptionsList
+  :: MonadNakadi b m
   => Maybe ApplicationName
   -> Maybe [EventTypeName]
   -> m [Subscription]

--- a/src/Network/Nakadi/Subscriptions.hs
+++ b/src/Network/Nakadi/Subscriptions.hs
@@ -51,24 +51,35 @@ subscriptionCreate' :: MonadNakadi b m => SubscriptionRequest -> m Subscription
 subscriptionCreate' subscription = httpJsonBody
   status201
   [(ok200, errorSubscriptionExistsAlready)]
-  (setRequestMethod "POST" . setRequestPath path . setRequestBodyJSON subscription)
+  ( setRequestMethod "POST"
+  . setRequestPath path
+  . setRequestBodyJSON subscription
+  )
 
 -- | @POST@ to @\/subscriptions@. Creates a new subscription. Does not
 -- fail if the requested subscription does already exist.
-subscriptionCreate :: (MonadNakadi b m, MonadCatch m) => SubscriptionRequest -> m Subscription
-subscriptionCreate subscription = Safe.catchJust exceptionPredicate
-                                                 (subscriptionCreate' subscription)
-                                                 return
+subscriptionCreate
+  :: (MonadNakadi b m, MonadCatch m) => SubscriptionRequest -> m Subscription
+subscriptionCreate subscription = Safe.catchJust
+  exceptionPredicate
+  (subscriptionCreate' subscription)
+  return
  where
   exceptionPredicate (SubscriptionExistsAlready s) = Just s
   exceptionPredicate _                             = Nothing
 
 -- | @GET@ to @\/subscriptions@. Internal low-level interface.
-subscriptionsGet :: MonadNakadi b m => [(ByteString, ByteString)] -> m SubscriptionsListResponse
+subscriptionsGet
+  :: MonadNakadi b m
+  => [(ByteString, ByteString)]
+  -> m SubscriptionsListResponse
 subscriptionsGet queryParameters = httpJsonBody
   ok200
   []
-  (setRequestMethod "GET" . setRequestPath path . setRequestQueryParameters queryParameters)
+  ( setRequestMethod "GET"
+  . setRequestPath path
+  . setRequestQueryParameters queryParameters
+  )
 
 buildQueryParameters
   :: Maybe ApplicationName
@@ -76,15 +87,19 @@ buildQueryParameters
   -> Maybe Limit
   -> Maybe Offset
   -> [(ByteString, ByteString)]
-buildQueryParameters maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset =
-  catMaybes
-    $  [ ("owning_application", ) . encodeUtf8 . unApplicationName <$> maybeOwningApp
+buildQueryParameters maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset
+  = catMaybes
+    $  [ ("owning_application", )
+       .   encodeUtf8
+       .   unApplicationName
+       <$> maybeOwningApp
        , ("limit", ) . encodeUtf8 . tshow <$> maybeLimit
        , ("offset", ) . encodeUtf8 . tshow <$> maybeOffset
        ]
     ++ case maybeEventTypeNames of
-         Just eventTypeNames ->
-           map (Just . ("event_type", ) . encodeUtf8 . unEventTypeName) eventTypeNames
+         Just eventTypeNames -> map
+           (Just . ("event_type", ) . encodeUtf8 . unEventTypeName)
+           eventTypeNames
          Nothing -> []
 
 -- | @GET@ to @\/subscriptions@. Retrieves all subscriptions matching
@@ -96,10 +111,13 @@ subscriptionsList'
   -> Maybe Limit
   -> Maybe Offset
   -> m SubscriptionsListResponse
-subscriptionsList' maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset = subscriptionsGet
-  queryParameters
+subscriptionsList' maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset =
+  subscriptionsGet queryParameters
  where
-  queryParameters = buildQueryParameters maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset
+  queryParameters = buildQueryParameters maybeOwningApp
+                                         maybeEventTypeNames
+                                         maybeLimit
+                                         maybeOffset
 
 -- | @GET@ to @\/subscriptions@. Retrieves all subscriptions matching
 -- the provided filter criteria. High-level Conduit interface.
@@ -108,22 +126,28 @@ subscriptionsSource
   => Maybe ApplicationName
   -> Maybe [EventTypeName]
   -> m (ConduitM () [Subscription] m ())
-subscriptionsSource maybeOwningApp maybeEventTypeNames = pure $ nextPage initialQueryParameters
+subscriptionsSource maybeOwningApp maybeEventTypeNames = pure
+  $ nextPage initialQueryParameters
  where
   nextPage queryParameters = do
     resp <- lift $ subscriptionsGet queryParameters
     yield (resp ^. L.items)
-    let maybeNextPath = Text.unpack . (view L.href) <$> (resp ^. L.links . L.next)
+    let maybeNextPath =
+          Text.unpack . (view L.href) <$> (resp ^. L.links . L.next)
     case maybeNextPath >>= extractQueryParametersFromPath of
       Just nextQueryParameters -> nextPage nextQueryParameters
       Nothing                  -> return ()
 
-  initialQueryParameters = buildQueryParameters maybeOwningApp maybeEventTypeNames Nothing Nothing
+  initialQueryParameters =
+    buildQueryParameters maybeOwningApp maybeEventTypeNames Nothing Nothing
 
 -- | @GET@ to @\/subscriptions@. Retrieves all subscriptions matching
 -- the provided filter criteria. High-level list interface.
 subscriptionsList
-  :: MonadNakadi b m => Maybe ApplicationName -> Maybe [EventTypeName] -> m [Subscription]
+  :: MonadNakadi b m
+  => Maybe ApplicationName
+  -> Maybe [EventTypeName]
+  -> m [Subscription]
 subscriptionsList maybeOwningApp maybeEventTypeNames = do
   source <- subscriptionsSource maybeOwningApp maybeEventTypeNames
   runConduit $ source .| concatC .| sinkList

--- a/src/Network/Nakadi/Types/Service.hs
+++ b/src/Network/Nakadi/Types/Service.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Network.Nakadi.Types.Service
 Description : Nakadi Service Types
-Copyright   : (c) Moritz Schulte 2017, 2018
+Copyright   : (c) Moritz Clasmeier 2017, 2018
 License     : BSD3
 Maintainer  : mtesseract@silverratio.net
 Stability   : experimental
@@ -35,6 +35,7 @@ module Network.Nakadi.Types.Service
   , CursorDistanceResult(..)
   , SubscriptionPosition(..)
   , Subscription(..)
+  , SubscriptionRequest(..)
   , PublishingStatus(..)
   , Step(..)
   , BatchItemResponse(..)

--- a/tests/Network/Nakadi/EventTypes/Test.hs
+++ b/tests/Network/Nakadi/EventTypes/Test.hs
@@ -13,6 +13,7 @@ import           Data.Function                  ( (&) )
 import           Network.Nakadi
 import           Network.Nakadi.EventTypes.CursorsLag.Test
 import           Network.Nakadi.EventTypes.ShiftedCursors.Test
+import           Network.Nakadi.EventTypes.BusinessEvents.Test
 import qualified Network.Nakadi.Lenses         as L
 import qualified Data.Vector                   as Vector
 import           Network.Nakadi.Tests.Common

--- a/tests/Network/Nakadi/EventTypes/Test.hs
+++ b/tests/Network/Nakadi/EventTypes/Test.hs
@@ -9,33 +9,34 @@
 
 module Network.Nakadi.EventTypes.Test where
 
-import           ClassyPrelude                                 hiding
-                                                                (withAsync)
+import           ClassyPrelude           hiding ( withAsync )
 
 import           Control.Lens
-import           Data.Function                                 ((&))
+import           Data.Function                  ( (&) )
 import           Network.Nakadi
 import           Network.Nakadi.EventTypes.CursorsLag.Test
 import           Network.Nakadi.EventTypes.ShiftedCursors.Test
-import qualified Network.Nakadi.Lenses                         as L
-import qualified Data.Vector as Vector
+import qualified Network.Nakadi.Lenses         as L
+import qualified Data.Vector                   as Vector
 import           Network.Nakadi.Tests.Common
 import           Test.Tasty
 import           Test.Tasty.HUnit
-import System.IO.Unsafe
+import           System.IO.Unsafe
 import           UnliftIO.Async
 
 testEventTypes :: Config App -> TestTree
-testEventTypes conf = testGroup "EventTypes"
-  [ testCase "EventTypesPrepare" (testEventTypesPrepare conf)
-  , testCase "EventTypesGet" (testEventTypesGet conf)
+testEventTypes conf = testGroup
+  "EventTypes"
+  [ testCase "EventTypesPrepare"            (testEventTypesPrepare conf)
+  , testCase "EventTypesGet"                (testEventTypesGet conf)
   , testCase "EventTypesDeleteCreateAndGet" (testEventTypesDeleteCreateGet conf)
-  , testCase "EventTypePartitionsGet" (testEventTypePartitionsGet conf)
-  , testCase "EventTypeCursorDistances0" (testEventTypeCursorDistances0 conf)
-  , testCase "EventTypeCursorDistances10" (testEventTypeCursorDistances10 conf)
-  , testCase "EventTypePublishData" (testEventTypePublishData conf)
-  , testCase "EventTypeParseFlowId" (testEventTypeParseFlowId conf)
-  , testCase "EventTypeDeserializationFailureException" (testEventTypeDeserializationFailureException conf)
+  , testCase "EventTypePartitionsGet"       (testEventTypePartitionsGet conf)
+  , testCase "EventTypeCursorDistances0"    (testEventTypeCursorDistances0 conf)
+  , testCase "EventTypeCursorDistances10"   (testEventTypeCursorDistances10 conf)
+  , testCase "EventTypePublishData"         (testEventTypePublishData conf)
+  , testCase "EventTypeParseFlowId"         (testEventTypeParseFlowId conf)
+  , testCase "EventTypeDeserializationFailureException"
+             (testEventTypeDeserializationFailureException conf)
   , testCase "EventTypeDeserializationFailure" (testEventTypeDeserializationFailure conf)
   , testEventTypesShiftedCursors conf
   , testEventTypesCursorsLag conf
@@ -44,12 +45,11 @@ testEventTypes conf = testGroup "EventTypes"
 testEventTypesPrepare :: Config App -> Assertion
 testEventTypesPrepare conf = runApp . runNakadiT conf $ do
   subscriptions <- subscriptionsList Nothing Nothing
-  let subscriptionIds = catMaybes . map (view L.id) $ subscriptions
+  let subscriptionIds = map (view L.id) $ subscriptions
   forM_ subscriptionIds subscriptionDelete
 
 testEventTypesGet :: Config App -> Assertion
-testEventTypesGet conf = runApp . runNakadiT conf $
-  void eventTypesList
+testEventTypesGet conf = runApp . runNakadiT conf $ void eventTypesList
 
 testEventTypesDeleteCreateGet :: Config App -> Assertion
 testEventTypesDeleteCreateGet conf = runApp . runNakadiT conf $ do
@@ -60,7 +60,6 @@ testEventTypesDeleteCreateGet conf = runApp . runNakadiT conf $ do
   eventTypeDelete myEventTypeName
   myEventTypes' <- filterMyEvent <$> eventTypesList
   liftIO $ length myEventTypes' @=? 0
-
   where filterMyEvent = filter ((myEventTypeName ==) . (view L.name))
 
 testEventTypePartitionsGet :: Config App -> Assertion
@@ -86,70 +85,63 @@ testEventTypeCursorDistances10 conf = runApp . runNakadiT conf $ do
   partitions <- eventTypePartitions myEventTypeName
   let cursors = map extractCursor partitions
 
-  forM_ [1..10] $ \_ -> do
+  forM_ [1 .. 10] $ \_ -> do
     now <- liftIO getCurrentTime
     eid <- EventId <$> genRandomUUID
     eventsPublish myEventTypeName [myDataChangeEvent eid now]
 
-  cursorPairs <- forM cursors $ \cursor@Cursor { .. } -> do
+  cursorPairs <- forM cursors $ \cursor@Cursor {..} -> do
     part <- eventTypePartition myEventTypeName _partition
     let cursor' = extractCursor part
     return (cursor, cursor')
 
-  distances <- forM cursorPairs $ \(c, c') -> do
-    cursorDistance myEventTypeName c c'
+  distances <- forM cursorPairs $ \(c, c') -> cursorDistance myEventTypeName c c'
 
   let totalDistances = sum distances
   liftIO $ totalDistances @=? 10
 
-mySubscription :: Subscription
-mySubscription = Subscription
-  { _id = Nothing
-  , _owningApplication = "test-suite"
-  , _eventTypes = [EventTypeName "test.FOO"]
-  , _consumerGroup = Nothing -- ??
-  , _createdAt = Nothing
-  , _readFrom = Just SubscriptionPositionEnd
-  , _initialCursors = Nothing
+mySubscription :: SubscriptionRequest
+mySubscription = SubscriptionRequest
+  { _owningApplication    = "test-suite"
+  , _eventTypes           = [EventTypeName "test.FOO"]
+  , _consumerGroup        = Nothing
+  , _subscriptionPosition = Nothing
   }
 
-createMySubscription :: (MonadUnliftIO m, MonadNakadi b m)
-                     => m SubscriptionId
+createMySubscription :: (MonadUnliftIO m, MonadNakadi b m) => m SubscriptionId
 createMySubscription = do
-  newSubscription <- subscriptionCreate mySubscription `catch`
-                     \ case
-                       SubscriptionExistsAlready s -> pure s
-                       exn -> throwIO exn
-  let (Just subscriptionId) = newSubscription^.L.id
-  pure subscriptionId
+  newSubscription <- subscriptionCreate mySubscription `catch` \case
+    SubscriptionExistsAlready s -> pure s
+    exn                         -> throwIO exn
+  pure (newSubscription ^. L.id)
 
 consumeParametersSingle :: ConsumeParameters
-consumeParametersSingle = defaultConsumeParameters
-                          & setBatchLimit 1
-                          & setBatchFlushTimeout 1
+consumeParametersSingle = defaultConsumeParameters & setBatchLimit 1 & setBatchFlushTimeout 1
 
 testEventTypePublishData :: Config App -> Assertion
 testEventTypePublishData conf = runApp . runNakadiT conf $ do
   now <- liftIO getCurrentTime
   eid <- EventId <$> genRandomUUID
   recreateEvent myEventType
-  let event = DataChangeEvent { _payload = Foo "Hello!"
-                              , _metadata = EventMetadata { _eid = eid
-                                                          , _occurredAt = Timestamp now
-                                                          , _parentEids = Nothing
-                                                          , _partition  = Nothing
-                                                          }
-                              , _dataType = "test.FOO"
-                              , _dataOp = DataOpUpdate
-                              }
+  let event = DataChangeEvent
+        { _payload  = Foo "Hello!"
+        , _metadata = EventMetadata
+          { _eid        = eid
+          , _occurredAt = Timestamp now
+          , _parentEids = Nothing
+          , _partition  = Nothing
+          }
+        , _dataType = "test.FOO"
+        , _dataOp   = DataOpUpdate
+        }
   subscriptionId <- createMySubscription
-  batchTv <- newTVarIO Nothing
-  res <- try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
+  batchTv        <- newTVarIO Nothing
+  res            <- try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
     liftIO $ link asyncHandle
     subscriptionProcess (Just consumeParametersSingle) subscriptionId (storeBatch batchTv)
   liftIO $ (Left TerminateConsumption) @=? res
   Just batch <- atomically $ readTVar batchTv
-  let Just events = batch^.L.events :: Maybe (Vector (DataChangeEvent Foo))
+  let Just events = batch ^. L.events :: Maybe (Vector (DataChangeEvent Foo))
   liftIO $ True @=? (Vector.length events > 0)
 
 storeBatch
@@ -166,82 +158,82 @@ testEventTypeParseFlowId conf = runApp . runNakadiT conf $ do
   now <- liftIO getCurrentTime
   eid <- EventId <$> genRandomUUID
   recreateEvent myEventType
-  let event = DataChangeEvent { _payload = Foo "Hello!"
-                              , _metadata = EventMetadata { _eid = eid
-                                                          , _occurredAt = Timestamp now
-                                                          , _parentEids = Nothing
-                                                          , _partition  = Nothing
-                                                          }
-                              , _dataType = "test.FOO"
-                              , _dataOp = DataOpUpdate
-                              }
+  let event = DataChangeEvent
+        { _payload  = Foo "Hello!"
+        , _metadata = EventMetadata
+          { _eid        = eid
+          , _occurredAt = Timestamp now
+          , _parentEids = Nothing
+          , _partition  = Nothing
+          }
+        , _dataType = "test.FOO"
+        , _dataOp   = DataOpUpdate
+        }
       expectedFlowId = Just $ FlowId "12345"
   subscriptionId <- createMySubscription
-  batchTv <- newTVarIO Nothing
-  res <- try $ withAsync (delayedPublish expectedFlowId [event]) $ \ asyncHandle -> do
+  batchTv        <- newTVarIO Nothing
+  res            <- try $ withAsync (delayedPublish expectedFlowId [event]) $ \asyncHandle -> do
     liftIO $ link asyncHandle
     subscriptionProcess (Just consumeParametersSingle) subscriptionId (storeBatch batchTv)
   liftIO $ (Left TerminateConsumption) @=? res
   Just batch <- atomically $ readTVar batchTv
-  let Just (e:_) = toList <$> (batch^.L.events) :: Maybe [DataChangeEventEnriched Foo]
-  liftIO $ expectedFlowId @=? e^.L.metadata.L.flowId
+  let Just (e : _) = toList <$> (batch ^. L.events) :: Maybe [DataChangeEventEnriched Foo]
+  liftIO $ expectedFlowId @=? e ^. L.metadata . L.flowId
 
 testEventTypeDeserializationFailureException :: Config App -> Assertion
 testEventTypeDeserializationFailureException conf = runApp . runNakadiT conf $ do
   now <- liftIO getCurrentTime
   eid <- EventId <$> genRandomUUID
   recreateEvent myEventType
-  let event = DataChangeEvent { _payload = Foo "Hello!"
-                              , _metadata = EventMetadata { _eid = eid
-                                                          , _occurredAt = Timestamp now
-                                                          , _parentEids = Nothing
-                                                          , _partition  = Nothing
-                                                          }
-                              , _dataType = "test.FOO"
-                              , _dataOp = DataOpUpdate
-                              }
-  subscriptionId <- createMySubscription
-  res :: Either NakadiException () <- try $
-    withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
-    liftIO $ link asyncHandle
-    subscriptionProcess (Just consumeParametersSingle) subscriptionId $
-      \ (_batch :: SubscriptionEventStreamBatch ()) -> pure ()
+  let event = DataChangeEvent
+        { _payload  = Foo "Hello!"
+        , _metadata = EventMetadata
+          { _eid        = eid
+          , _occurredAt = Timestamp now
+          , _parentEids = Nothing
+          , _partition  = Nothing
+          }
+        , _dataType = "test.FOO"
+        , _dataOp   = DataOpUpdate
+        }
+  subscriptionId                   <- createMySubscription
+  res :: Either NakadiException () <-
+    try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
+      liftIO $ link asyncHandle
+      subscriptionProcess (Just consumeParametersSingle) subscriptionId
+        $ \(_batch :: SubscriptionEventStreamBatch ()) -> pure ()
   case res of
-    Left (DeserializationFailure _ _) ->
-      pure ()
-    Left exn ->
-      liftIO $ assertFailure $ "Unexpected exception: " <> show exn
-    Right events ->
-      liftIO $ assertFailure $ "Unexpected success: " <> show events
+    Left (DeserializationFailure _ _) -> pure ()
+    Left exn -> liftIO $ assertFailure $ "Unexpected exception: " <> show exn
+    Right events -> liftIO $ assertFailure $ "Unexpected success: " <> show events
 
 testEventTypeDeserializationFailure :: Config App -> Assertion
 testEventTypeDeserializationFailure conf' = runApp . runNakadiT conf $ do
   now <- liftIO getCurrentTime
   eid <- EventId <$> genRandomUUID
   recreateEvent myEventType
-  let event = DataChangeEvent { _payload = Foo "Hello!"
-                              , _metadata = EventMetadata { _eid = eid
-                                                          , _occurredAt = Timestamp now
-                                                          , _parentEids = Nothing
-                                                          , _partition  = Nothing
-                                                          }
-                              , _dataType = "test.FOO"
-                              , _dataOp = DataOpUpdate
-                              }
+  let event = DataChangeEvent
+        { _payload  = Foo "Hello!"
+        , _metadata = EventMetadata
+          { _eid        = eid
+          , _occurredAt = Timestamp now
+          , _parentEids = Nothing
+          , _partition  = Nothing
+          }
+        , _dataType = "test.FOO"
+        , _dataOp   = DataOpUpdate
+        }
   subscriptionId <- createMySubscription
-  res <- try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
+  res            <- try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
     liftIO $ link asyncHandle
-    subscriptionProcess (Just consumeParametersSingle) subscriptionId $
-      \ (_batch :: SubscriptionEventStreamBatch WrongFoo) ->
-        throwIO TerminateConsumption
+    subscriptionProcess (Just consumeParametersSingle) subscriptionId
+      $ \(_batch :: SubscriptionEventStreamBatch WrongFoo) -> throwIO TerminateConsumption
   liftIO $ Left TerminateConsumption @=? res
   counter <- atomically $ readTVar deserializationFailureCounter
   liftIO $ 1 @=? counter
+ where
+  conf = conf' & setDeserializationFailureCallback deserializationFailureCb
 
-  where conf = conf'
-               & setDeserializationFailureCallback deserializationFailureCb
+  deserializationFailureCb _ _ = atomically $ modifyTVar deserializationFailureCounter (+ 1)
 
-        deserializationFailureCb _ _ =
-          atomically $ modifyTVar deserializationFailureCounter (+ 1)
-
-        deserializationFailureCounter = unsafePerformIO $ newTVarIO 0
+  deserializationFailureCounter = unsafePerformIO $ newTVarIO 0

--- a/tests/Network/Nakadi/EventTypes/Test.hs
+++ b/tests/Network/Nakadi/EventTypes/Test.hs
@@ -29,12 +29,13 @@ testEventTypes conf = testGroup
   , testCase "EventTypesDeleteCreateAndGet" (testEventTypesDeleteCreateGet conf)
   , testCase "EventTypePartitionsGet"       (testEventTypePartitionsGet conf)
   , testCase "EventTypeCursorDistances0"    (testEventTypeCursorDistances0 conf)
-  , testCase "EventTypeCursorDistances10"   (testEventTypeCursorDistances10 conf)
+  , testCase "EventTypeCursorDistances10" (testEventTypeCursorDistances10 conf)
   , testCase "EventTypePublishData"         (testEventTypePublishData conf)
   , testCase "EventTypeParseFlowId"         (testEventTypeParseFlowId conf)
   , testCase "EventTypeDeserializationFailureException"
              (testEventTypeDeserializationFailureException conf)
-  , testCase "EventTypeDeserializationFailure" (testEventTypeDeserializationFailure conf)
+  , testCase "EventTypeDeserializationFailure"
+             (testEventTypeDeserializationFailure conf)
   , testEventTypesShiftedCursors conf
   , testEventTypesCursorsLag conf
   , testBusinessEvents conf
@@ -93,7 +94,8 @@ testEventTypeCursorDistances10 conf = runApp . runNakadiT conf $ do
     let cursor' = extractCursor part
     return (cursor, cursor')
 
-  distances <- forM cursorPairs $ \(c, c') -> cursorDistance myEventTypeName c c'
+  distances <- forM cursorPairs
+    $ \(c, c') -> cursorDistance myEventTypeName c c'
 
   let totalDistances = sum distances
   liftIO $ totalDistances @=? 10
@@ -114,7 +116,8 @@ createMySubscription = do
   pure (newSubscription ^. L.id)
 
 consumeParametersSingle :: ConsumeParameters
-consumeParametersSingle = defaultConsumeParameters & setBatchLimit 1 & setBatchFlushTimeout 1
+consumeParametersSingle =
+  defaultConsumeParameters & setBatchLimit 1 & setBatchFlushTimeout 1
 
 testEventTypePublishData :: Config App -> Assertion
 testEventTypePublishData conf = runApp . runNakadiT conf $ do
@@ -133,10 +136,12 @@ testEventTypePublishData conf = runApp . runNakadiT conf $ do
         , _dataOp   = DataOpUpdate
         }
   subscriptionId <- createMySubscription
-  batchTv        <- newTVarIO Nothing
-  res            <- try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
+  batchTv <- newTVarIO Nothing
+  res <- try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
     liftIO $ link asyncHandle
-    subscriptionProcess (Just consumeParametersSingle) subscriptionId (storeBatch batchTv)
+    subscriptionProcess (Just consumeParametersSingle)
+                        subscriptionId
+                        (storeBatch batchTv)
   liftIO $ (Left TerminateConsumption) @=? res
   Just batch <- atomically $ readTVar batchTv
   let Just events = batch ^. L.events :: Maybe (Vector (DataChangeEvent Foo))
@@ -170,40 +175,46 @@ testEventTypeParseFlowId conf = runApp . runNakadiT conf $ do
       expectedFlowId = Just $ FlowId "12345"
   subscriptionId <- createMySubscription
   batchTv        <- newTVarIO Nothing
-  res            <- try $ withAsync (delayedPublish expectedFlowId [event]) $ \asyncHandle -> do
-    liftIO $ link asyncHandle
-    subscriptionProcess (Just consumeParametersSingle) subscriptionId (storeBatch batchTv)
+  res            <-
+    try $ withAsync (delayedPublish expectedFlowId [event]) $ \asyncHandle -> do
+      liftIO $ link asyncHandle
+      subscriptionProcess (Just consumeParametersSingle)
+                          subscriptionId
+                          (storeBatch batchTv)
   liftIO $ (Left TerminateConsumption) @=? res
   Just batch <- atomically $ readTVar batchTv
-  let Just (e : _) = toList <$> (batch ^. L.events) :: Maybe [DataChangeEventEnriched Foo]
+  let Just (e : _) =
+        toList <$> (batch ^. L.events) :: Maybe [DataChangeEventEnriched Foo]
   liftIO $ expectedFlowId @=? e ^. L.metadata . L.flowId
 
 testEventTypeDeserializationFailureException :: Config App -> Assertion
-testEventTypeDeserializationFailureException conf = runApp . runNakadiT conf $ do
-  now <- liftIO getCurrentTime
-  eid <- EventId <$> genRandomUUID
-  recreateEvent myEventType
-  let event = DataChangeEvent
-        { _payload  = Foo "Hello!"
-        , _metadata = EventMetadata
-          { _eid        = eid
-          , _occurredAt = Timestamp now
-          , _parentEids = Nothing
-          , _partition  = Nothing
+testEventTypeDeserializationFailureException conf =
+  runApp . runNakadiT conf $ do
+    now <- liftIO getCurrentTime
+    eid <- EventId <$> genRandomUUID
+    recreateEvent myEventType
+    let event = DataChangeEvent
+          { _payload  = Foo "Hello!"
+          , _metadata = EventMetadata
+            { _eid        = eid
+            , _occurredAt = Timestamp now
+            , _parentEids = Nothing
+            , _partition  = Nothing
+            }
+          , _dataType = "test.FOO"
+          , _dataOp   = DataOpUpdate
           }
-        , _dataType = "test.FOO"
-        , _dataOp   = DataOpUpdate
-        }
-  subscriptionId                   <- createMySubscription
-  res :: Either NakadiException () <-
-    try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
-      liftIO $ link asyncHandle
-      subscriptionProcess (Just consumeParametersSingle) subscriptionId
-        $ \(_batch :: SubscriptionEventStreamBatch ()) -> pure ()
-  case res of
-    Left (DeserializationFailure _ _) -> pure ()
-    Left exn -> liftIO $ assertFailure $ "Unexpected exception: " <> show exn
-    Right events -> liftIO $ assertFailure $ "Unexpected success: " <> show events
+    subscriptionId                   <- createMySubscription
+    res :: Either NakadiException () <-
+      try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
+        liftIO $ link asyncHandle
+        subscriptionProcess (Just consumeParametersSingle) subscriptionId
+          $ \(_batch :: SubscriptionEventStreamBatch ()) -> pure ()
+    case res of
+      Left (DeserializationFailure _ _) -> pure ()
+      Left exn -> liftIO $ assertFailure $ "Unexpected exception: " <> show exn
+      Right events ->
+        liftIO $ assertFailure $ "Unexpected success: " <> show events
 
 testEventTypeDeserializationFailure :: Config App -> Assertion
 testEventTypeDeserializationFailure conf' = runApp . runNakadiT conf $ do
@@ -222,16 +233,18 @@ testEventTypeDeserializationFailure conf' = runApp . runNakadiT conf $ do
         , _dataOp   = DataOpUpdate
         }
   subscriptionId <- createMySubscription
-  res            <- try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
+  res <- try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
     liftIO $ link asyncHandle
     subscriptionProcess (Just consumeParametersSingle) subscriptionId
-      $ \(_batch :: SubscriptionEventStreamBatch WrongFoo) -> throwIO TerminateConsumption
+      $ \(_batch :: SubscriptionEventStreamBatch WrongFoo) ->
+          throwIO TerminateConsumption
   liftIO $ Left TerminateConsumption @=? res
   counter <- atomically $ readTVar deserializationFailureCounter
   liftIO $ 1 @=? counter
  where
   conf = conf' & setDeserializationFailureCallback deserializationFailureCb
 
-  deserializationFailureCb _ _ = atomically $ modifyTVar deserializationFailureCounter (+ 1)
+  deserializationFailureCb _ _ =
+    atomically $ modifyTVar deserializationFailureCounter (+ 1)
 
   deserializationFailureCounter = unsafePerformIO $ newTVarIO 0

--- a/tests/Network/Nakadi/Examples/Subscription/Test.hs
+++ b/tests/Network/Nakadi/Examples/Subscription/Test.hs
@@ -44,7 +44,8 @@ testConsumption config = Nakadi.runNakadiT config $ do
     _ <- flip runLoggingT (logger nakadiLogRef) $ do
       events <- genEvents
       void . async $ delayedPublish Nothing events
-      withAsync (dumpSubscription subscriptionId) $ \_dumpHandle -> threadDelay (2 * 10 ^ 6) -- Give Nakadi some time to transmit the published events
+      withAsync (dumpSubscription subscriptionId)
+        $ \_dumpHandle -> threadDelay (2 * 10 ^ 6) -- Give Nakadi some time to transmit the published events
     nakadiLog <- liftIO $ readIORef nakadiLogRef
     when (length nakadiLog == 0) $ liftIO $ assertFailure
       "Subscription Consumption has logged no received batches"

--- a/tests/Network/Nakadi/Examples/Subscription/Test.hs
+++ b/tests/Network/Nakadi/Examples/Subscription/Test.hs
@@ -4,15 +4,15 @@
 
 module Network.Nakadi.Examples.Subscription.Test
   ( testConsumption
-  ) where
+  )
+where
 
 import           ClassyPrelude
 import           Control.Lens
 import           Control.Monad.Logger
-import           Data.Maybe                                   (fromJust)
-import qualified Network.Nakadi                               as Nakadi
+import qualified Network.Nakadi                as Nakadi
 import           Network.Nakadi.Examples.Subscription.Process
-import qualified Network.Nakadi.Lenses                        as L
+import qualified Network.Nakadi.Lenses         as L
 import           Network.Nakadi.Tests.Common
 import           Test.Tasty.HUnit
 import           UnliftIO.Concurrent
@@ -22,54 +22,50 @@ genEvent = do
   now <- liftIO getCurrentTime
   eid <- Nakadi.EventId <$> genRandomUUID
   let event = Nakadi.DataChangeEvent
-        { Nakadi._payload = Foo "Hello!"
+        { Nakadi._payload  = Foo "Hello!"
         , Nakadi._metadata = Nakadi.EventMetadata
-                             { Nakadi._eid = eid
-                             , Nakadi._occurredAt = Nakadi.Timestamp now
-                             , Nakadi._parentEids = Nothing
-                             , Nakadi._partition = Nothing
-                             }
+          { Nakadi._eid        = eid
+          , Nakadi._occurredAt = Nakadi.Timestamp now
+          , Nakadi._parentEids = Nothing
+          , Nakadi._partition  = Nothing
+          }
         , Nakadi._dataType = "test.FOO"
-        , Nakadi._dataOp = Nakadi.DataOpUpdate
+        , Nakadi._dataOp   = Nakadi.DataOpUpdate
         }
   pure event
 
 genEvents :: MonadIO m => m [Nakadi.DataChangeEvent Foo]
-genEvents =
-  sequence (replicate 10 genEvent)
+genEvents = sequence (replicate 10 genEvent)
 
 testConsumption :: Nakadi.Config IO -> Assertion
 testConsumption config = Nakadi.runNakadiT config $ do
   nakadiLogRef <- liftIO $ newIORef []
-  bracket before after $ \ subscriptionId -> do
+  bracket before after $ \subscriptionId -> do
     _ <- flip runLoggingT (logger nakadiLogRef) $ do
       events <- genEvents
       void . async $ delayedPublish Nothing events
-      withAsync (dumpSubscription subscriptionId) $ \ _dumpHandle ->
-        threadDelay (2 * 10^6) -- Give Nakadi some time to transmit the published events
+      withAsync (dumpSubscription subscriptionId)
+        $ \_dumpHandle -> threadDelay (2 * 10 ^ 6) -- Give Nakadi some time to transmit the published events
     nakadiLog <- liftIO $ readIORef nakadiLogRef
-    when (length nakadiLog == 0) $
-      liftIO $ assertFailure "Subscription Consumption has logged no received batches"
+    when (length nakadiLog == 0) $ liftIO $ assertFailure
+      "Subscription Consumption has logged no received batches"
+ where
+  before = do
+    recreateEvent myEventType
+    subscription <- Nakadi.subscriptionCreate Nakadi.SubscriptionRequest
+      { _owningApplication    = "test-suite"
+      , _eventTypes           = [myEventTypeName]
+      , _consumerGroup        = Nothing -- ??
+      , _subscriptionPosition = Just Nakadi.SubscriptionPositionEnd
+      }
+    pure $ subscription ^. L.id
 
-  where before = do
-          recreateEvent myEventType
-          subscription <- Nakadi.subscriptionCreate Nakadi.Subscription
-            { _id = Nothing
-            , _owningApplication = "test-suite"
-            , _eventTypes = [myEventTypeName]
-            , _consumerGroup = Nothing -- ??
-            , _createdAt = Nothing
-            , _readFrom = Just Nakadi.SubscriptionPositionEnd
-            , _initialCursors = Nothing
-            }
-          pure . fromJust $ subscription^.L.id
+  after subscriptionId = do
+    Nakadi.subscriptionDelete subscriptionId
+    Nakadi.eventTypeDelete myEventTypeName `catch` (ignoreExnNotFound ())
 
-        after subscriptionId = do
-          Nakadi.subscriptionDelete subscriptionId
-          Nakadi.eventTypeDelete myEventTypeName `catch` (ignoreExnNotFound ())
+  -- nEvents = 100
 
-        -- nEvents = 100
-
-        logger nakadiLog loc logSource logLevel logStr = do
-          let str = defaultLogStr loc logSource logLevel logStr
-          liftIO $ modifyIORef nakadiLog (str :)
+  logger nakadiLog loc logSource logLevel logStr = do
+    let str = defaultLogStr loc logSource logLevel logStr
+    liftIO $ modifyIORef nakadiLog (str :)

--- a/tests/Network/Nakadi/Internal/Types/Test.hs
+++ b/tests/Network/Nakadi/Internal/Types/Test.hs
@@ -67,11 +67,11 @@ testDecodeCursorCommitResults = do
   let eventType = "http4s-nakadi.test-event"
       offset =  "001-0001-000000000000007598"
       cursorToken = "3bb3a590-ede5-43a9-981e-2bea26347c99"
-      partition = "0"
+      partitionName = "0"
       result = CursorCommitResultOutdated
       cursorCommitResultsJson
        = encode [aesonQQ|
-          { items: [ { cursor: { partition: #{partition}
+          { items: [ { cursor: { partition: #{partitionName}
                                , offset: #{offset}
                                , event_type: #{eventType}
                                , cursor_token: #{cursorToken}
@@ -81,7 +81,7 @@ testDecodeCursorCommitResults = do
                    ]
           }
         |]
-      cursor = SubscriptionCursor { _partition = partition
+      cursor = SubscriptionCursor { _partition = partitionName
                                   , _offset = offset
                                   , _eventType = eventType
                                   , _cursorToken = cursorToken}

--- a/tests/Network/Nakadi/Internal/Types/Test.hs
+++ b/tests/Network/Nakadi/Internal/Types/Test.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
 
 module Network.Nakadi.Internal.Types.Test where
 
@@ -8,6 +9,8 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Data.Aeson
 import           Network.Nakadi.Types.Service
+import           Data.Aeson.QQ
+import Data.Maybe (fromJust)
 
 testTypes :: TestTree
 testTypes = testGroup "Types" [testService]
@@ -34,26 +37,12 @@ testDecodeSubscriptionRequest = do
       , _consumerGroup        = Nothing
       , _subscriptionPosition = pos
       }
-    req'End
-      = "\
-         \{ \"owning_application\": \"test\" \
-         \, \"event_types\": [\"event1\"] \
-         \, \"read_from\": \"end\" \
-         \}"
-    req'Begin
-      = "\
-        \{ \"owning_application\": \"test\" \
-        \, \"event_types\": [\"event1\"] \
-        \, \"read_from\": \"begin\" \
-        \}"
+    req'End = encode [aesonQQ|{owning_application: "test", event_types: ["event1"], read_from: "end"}|]
+    req'Begin = encode
+      [aesonQQ|{owning_application: "test", event_types: ["event1"], read_from: "begin"}|]
+    cursors = [] :: [SubscriptionCursorWithoutToken]
     req'Cursors
-      = "\
-        \{ \"owning_application\": \"test\" \
-        \, \"event_types\": [\"event1\"] \
-        \, \"read_from\": \"cursors\" \
-        \, \"cursors\": [] \
-        \}"
-    cursors = []
+      = encode [aesonQQ|{owning_application: "test", event_types: ["event1"], read_from: "cursors", cursors: #{cursors}}|]
 
   assertBool "Failed to serialize SubscriptionRequest with SubscriptionPositionEnd"
              (jsonEqual (encode (req (Just SubscriptionPositionEnd))) req'End)
@@ -74,8 +63,28 @@ testDecodeSubscriptionRequest = do
              (jsonEqual (encode (req Nothing)) req'End)
 
 testDecodeCursorCommitResults :: Assertion
-testDecodeCursorCommitResults = assertBool "Failed to decode"
-  $ isJust (decode sampleResponse :: (Maybe CursorCommitResults))
- where
-  sampleResponse
-    = "{\"items\":[{\"cursor\":{\"partition\":\"0\",\"offset\":\"001-0001-000000000000007598\",\"event_type\":\"http4s-nakadi.test-event\",\"cursor_token\":\"3bb3a590-ede5-43a9-981e-2bea26347c99\"},\"result\":\"outdated\"}]}"
+testDecodeCursorCommitResults = do
+  let eventType = "http4s-nakadi.test-event"
+      offset =  "001-0001-000000000000007598"
+      cursorToken = "3bb3a590-ede5-43a9-981e-2bea26347c99"
+      partition = "0"
+      result = CursorCommitResultOutdated
+      cursorCommitResultsJson
+       = encode [aesonQQ|
+          { items: [ { cursor: { partition: #{partition}
+                               , offset: #{offset}
+                               , event_type: #{eventType}
+                               , cursor_token: #{cursorToken}
+                               },
+                       result: #{result}
+                     }
+                   ]
+          }
+        |]
+      cursor = SubscriptionCursor { _partition = partition
+                                  , _offset = offset
+                                  , _eventType = eventType
+                                  , _cursorToken = cursorToken}
+      cursorCommitResults = CursorCommitResults { _items = [CursorCommitResult { _cursor = cursor , _result = result }] }
+  assertBool "Failed to decode CursorsCommitResults" $
+    fromJust (decode cursorCommitResultsJson) == cursorCommitResults

--- a/tests/Network/Nakadi/Internal/Types/Test.hs
+++ b/tests/Network/Nakadi/Internal/Types/Test.hs
@@ -2,22 +2,80 @@
 
 module Network.Nakadi.Internal.Types.Test where
 
-import ClassyPrelude
-import Test.Tasty
-import Test.Tasty.HUnit
-import Data.Aeson
-import Network.Nakadi.Types.Service
+import qualified Data.ByteString.Lazy          as LB
+import           ClassyPrelude
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Data.Aeson
+import           Network.Nakadi.Types.Service
 
 testTypes :: TestTree
-testTypes = testGroup "Types"
-  [ testService
-  ]
+testTypes = testGroup "Types" [testService]
 
 testService :: TestTree
-testService = testGroup "Service"
-  [ testCase "JSON-decoding CursorCommitResults" testDecodeCursorCommitResults
+testService = testGroup
+  "Service"
+  [ testCase "JSON Decode: CursorCommitResults" testDecodeCursorCommitResults
+  , testCase "JSON Decode: SubscriptionRequest" testDecodeSubscriptionRequest
   ]
 
+jsonEqual :: LB.ByteString -> LB.ByteString -> Bool
+jsonEqual a b =
+  let Just a' = decode a :: Maybe Value
+      Just b' = decode b :: Maybe Value
+  in  a' == b'
+
+testDecodeSubscriptionRequest :: Assertion
+testDecodeSubscriptionRequest = do
+  let
+    req pos = SubscriptionRequest
+      { _owningApplication    = "test"
+      , _eventTypes           = ["event1"]
+      , _consumerGroup        = Nothing
+      , _subscriptionPosition = pos
+      }
+    req'End
+      = "\
+         \{ \"owning_application\": \"test\" \
+         \, \"event_types\": [\"event1\"] \
+         \, \"read_from\": \"end\" \
+         \}"
+    req'Begin
+      = "\
+        \{ \"owning_application\": \"test\" \
+        \, \"event_types\": [\"event1\"] \
+        \, \"read_from\": \"begin\" \
+        \}"
+    req'Cursors
+      = "\
+        \{ \"owning_application\": \"test\" \
+        \, \"event_types\": [\"event1\"] \
+        \, \"read_from\": \"cursors\" \
+        \, \"cursors\": [] \
+        \}"
+    cursors = []
+
+  assertBool "Failed to serialize SubscriptionRequest with SubscriptionPositionEnd"
+             (jsonEqual (encode (req (Just SubscriptionPositionEnd))) req'End)
+  assertBool "Failed to deserialize SubscriptionRequest with SubscriptionPositionEnd"
+             (decode req'End == Just (req (Just SubscriptionPositionEnd)))
+
+  assertBool "Failed to serialize SubscriptionRequest with SubscriptionPositionBegin"
+             (jsonEqual (encode (req (Just SubscriptionPositionBegin))) req'Begin)
+  assertBool "Failed to deserialize SubscriptionRequest with SubscriptionPositionBegin"
+             (decode req'Begin == Just (req (Just SubscriptionPositionBegin)))
+
+  assertBool "Failed to serialize SubscriptionRequest with SubscriptionPositionCursors"
+             (jsonEqual (encode (req (Just (SubscriptionPositionCursors cursors)))) req'Cursors)
+  assertBool "Failed to deserialize SubscriptionRequest with SubscriptionPositionCursors"
+             (decode req'Cursors == Just (req (Just (SubscriptionPositionCursors cursors))))
+
+  assertBool "Failed to serialize SubscriptionRequest without SubscriptionPosition"
+             (jsonEqual (encode (req Nothing)) req'End)
+
 testDecodeCursorCommitResults :: Assertion
-testDecodeCursorCommitResults = assertBool "Failed to decode" $ isJust (decode sampleResponse :: (Maybe CursorCommitResults))
-  where sampleResponse = "{\"items\":[{\"cursor\":{\"partition\":\"0\",\"offset\":\"001-0001-000000000000007598\",\"event_type\":\"http4s-nakadi.test-event\",\"cursor_token\":\"3bb3a590-ede5-43a9-981e-2bea26347c99\"},\"result\":\"outdated\"}]}"
+testDecodeCursorCommitResults = assertBool "Failed to decode"
+  $ isJust (decode sampleResponse :: (Maybe CursorCommitResults))
+ where
+  sampleResponse
+    = "{\"items\":[{\"cursor\":{\"partition\":\"0\",\"offset\":\"001-0001-000000000000007598\",\"event_type\":\"http4s-nakadi.test-event\",\"cursor_token\":\"3bb3a590-ede5-43a9-981e-2bea26347c99\"},\"result\":\"outdated\"}]}"

--- a/tests/Network/Nakadi/Subscriptions/Processing/Test.hs
+++ b/tests/Network/Nakadi/Subscriptions/Processing/Test.hs
@@ -11,27 +11,30 @@ import           ClassyPrelude
 import           Control.Lens
 import           Control.Monad.Logger
 import           Data.Aeson
-import           Data.Maybe                  (fromJust)
 import           Network.Nakadi
-import qualified Network.Nakadi.Lenses       as L
+import qualified Network.Nakadi.Lenses         as L
 import           Network.Nakadi.Tests.Common
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
 testSubscriptionsProcessing :: Config App -> TestTree
-testSubscriptionsProcessing confTemplate =
-  let mkConf commitStrategy = confTemplate
-                              & setCommitStrategy commitStrategy
-  in testGroup "Processing"
-     [ testCase "SubscriptionProcessing/async/TimeBuffer" $
-       testSubscriptionHighLevelProcessing (mkConf (CommitAsync (CommitTimeBuffer 200)))
-     , testCase "SubscriptionProcessing/sync" $
-       testSubscriptionHighLevelProcessing (mkConf CommitSync)
-     , testCase "SubscriptionProcessing/async/NoBuffer" $
-       testSubscriptionHighLevelProcessing (mkConf (CommitAsync CommitNoBuffer))
-     , testCase "SubscriptionProcessing/async/SmartBuffer" $
-       testSubscriptionHighLevelProcessing (mkConf (CommitAsync CommitSmartBuffer))
-     ]
+testSubscriptionsProcessing confTemplate
+  = let mkConf commitStrategy = confTemplate & setCommitStrategy commitStrategy
+    in
+      testGroup
+        "Processing"
+        [ testCase "SubscriptionProcessing/async/TimeBuffer"
+          $ testSubscriptionHighLevelProcessing
+              (mkConf (CommitAsync (CommitTimeBuffer 200)))
+        , testCase "SubscriptionProcessing/sync"
+          $ testSubscriptionHighLevelProcessing (mkConf CommitSync)
+        , testCase "SubscriptionProcessing/async/NoBuffer"
+          $ testSubscriptionHighLevelProcessing
+              (mkConf (CommitAsync CommitNoBuffer))
+        , testCase "SubscriptionProcessing/async/SmartBuffer"
+          $ testSubscriptionHighLevelProcessing
+              (mkConf (CommitAsync CommitSmartBuffer))
+        ]
 
 data ConsumptionDone = ConsumptionDone deriving (Show, Typeable)
 
@@ -43,54 +46,58 @@ testSubscriptionHighLevelProcessing conf = runApp $ do
   let logFunc src lev str = liftIO $ logger defaultLoc src lev str
   runNakadiT (conf & setLogFunc logFunc) $ do
     counter <- newIORef 0
-    events <- sequence $
-      map genMyDataChangeEventIdx [1..nEvents] :: NakadiT App App [DataChangeEvent Foo]
-    publishAndConsume events counter `catch` \ (_exn :: ConsumptionDone) -> pure ()
+    events  <-
+      sequence $ map genMyDataChangeEventIdx [1 .. nEvents] :: NakadiT
+        App
+        App
+        [DataChangeEvent Foo]
+    publishAndConsume events counter
+      `catch` \(_exn :: ConsumptionDone) -> pure ()
     eventsRead <- readIORef counter
     liftIO $ nEvents @=? eventsRead
+ where
+  before :: (MonadUnliftIO m, MonadNakadi App m) => m SubscriptionId
+  before = do
+    recreateEvent myEventType
+    subscription <- subscriptionCreate SubscriptionRequest
+      { _owningApplication    = "test-suite"
+      , _eventTypes           = [myEventTypeName]
+      , _consumerGroup        = Nothing -- ??
+      , _subscriptionPosition = Just SubscriptionPositionEnd
+      }
+    pure $ subscription ^. L.id
 
-  where before :: (MonadUnliftIO m, MonadNakadi App m) => m SubscriptionId
-        before = do
-          recreateEvent myEventType
-          subscription <- subscriptionCreate Subscription
-            { _id = Nothing
-            , _owningApplication = "test-suite"
-            , _eventTypes = [myEventTypeName]
-            , _consumerGroup = Nothing -- ??
-            , _createdAt = Nothing
-            , _readFrom = Just SubscriptionPositionEnd
-            , _initialCursors = Nothing
-            }
-          pure . fromJust $ subscription^.L.id
+  after :: (MonadUnliftIO m, MonadNakadi App m) => SubscriptionId -> m ()
+  after subscriptionId = do
+    subscriptionDelete subscriptionId
+    eventTypeDelete myEventTypeName `catch` (ignoreExnNotFound ())
 
-        after :: (MonadUnliftIO m, MonadNakadi App m) => SubscriptionId -> m ()
-        after subscriptionId = do
-          subscriptionDelete subscriptionId
-          eventTypeDelete myEventTypeName `catch` (ignoreExnNotFound ())
+  nEvents :: Int
+  nEvents = 10000
 
-        nEvents :: Int
-        nEvents = 10000
-
-        publishAndConsume :: (ToJSON a, FromJSON a, Show a)
-                          => [DataChangeEvent a]
-                          -> IORef Int
-                          -> NakadiT App App ()
-        publishAndConsume events counter =
-          bracket before after $ \ subscriptionId -> do
-          let n = length events
-          publisherHandle <- async $ do
-            delayedPublish Nothing events
-          liftIO $ linkAsync publisherHandle
-          forever $ do
-            subscriptionProcess (Just consumeParameters) subscriptionId $
-              \ (batch :: SubscriptionEventStreamBatch (DataChangeEvent Foo)) -> do
-                let eventsReceived = fromMaybe mempty (batch^.L.events)
+  publishAndConsume
+    :: (ToJSON a, FromJSON a, Show a)
+    => [DataChangeEvent a]
+    -> IORef Int
+    -> NakadiT App App ()
+  publishAndConsume events counter = bracket before after $ \subscriptionId ->
+    do
+      let n = length events
+      publisherHandle <- async $ do
+        delayedPublish Nothing events
+      liftIO $ linkAsync publisherHandle
+      forever $ do
+        subscriptionProcess (Just consumeParameters) subscriptionId
+          $ \(batch :: SubscriptionEventStreamBatch (DataChangeEvent Foo)) ->
+              do
+                let eventsReceived = fromMaybe mempty (batch ^. L.events)
                 modifyIORef counter (+ (length eventsReceived))
                 eventsRead <- readIORef counter
                 when (n <= eventsRead) $ throwIO ConsumptionDone
-            putStrLn $ "Subscription Processing terminated, will restart."
+        putStrLn $ "Subscription Processing terminated, will restart."
 
-        consumeParameters = defaultConsumeParameters
-                            & setBatchFlushTimeout 1
-                            & setMaxUncommittedEvents 5000
-                            & setBatchLimit 10
+  consumeParameters =
+    defaultConsumeParameters
+      & setBatchFlushTimeout 1
+      & setMaxUncommittedEvents 5000
+      & setBatchLimit 10

--- a/tests/Network/Nakadi/Subscriptions/Processing/Test.hs
+++ b/tests/Network/Nakadi/Subscriptions/Processing/Test.hs
@@ -18,18 +18,22 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 
 testSubscriptionsProcessing :: Config App -> TestTree
-testSubscriptionsProcessing confTemplate =
-  let mkConf commitStrategy = confTemplate & setCommitStrategy commitStrategy
-  in  testGroup
+testSubscriptionsProcessing confTemplate
+  = let mkConf commitStrategy = confTemplate & setCommitStrategy commitStrategy
+    in
+      testGroup
         "Processing"
         [ testCase "SubscriptionProcessing/async/TimeBuffer"
-          $ testSubscriptionHighLevelProcessing (mkConf (CommitAsync (CommitTimeBuffer 200)))
+          $ testSubscriptionHighLevelProcessing
+              (mkConf (CommitAsync (CommitTimeBuffer 200)))
         , testCase "SubscriptionProcessing/sync"
           $ testSubscriptionHighLevelProcessing (mkConf CommitSync)
         , testCase "SubscriptionProcessing/async/NoBuffer"
-          $ testSubscriptionHighLevelProcessing (mkConf (CommitAsync CommitNoBuffer))
+          $ testSubscriptionHighLevelProcessing
+              (mkConf (CommitAsync CommitNoBuffer))
         , testCase "SubscriptionProcessing/async/SmartBuffer"
-          $ testSubscriptionHighLevelProcessing (mkConf (CommitAsync CommitSmartBuffer))
+          $ testSubscriptionHighLevelProcessing
+              (mkConf (CommitAsync CommitSmartBuffer))
         ]
 
 data ConsumptionDone = ConsumptionDone deriving (Show, Typeable)
@@ -43,8 +47,12 @@ testSubscriptionHighLevelProcessing conf = runApp $ do
   runNakadiT (conf & setLogFunc logFunc) $ do
     counter <- newIORef 0
     events  <-
-      sequence $ map genMyDataChangeEventIdx [1 .. nEvents] :: NakadiT App App [DataChangeEvent Foo]
-    publishAndConsume events counter `catch` \(_exn :: ConsumptionDone) -> pure ()
+      sequence $ map genMyDataChangeEventIdx [1 .. nEvents] :: NakadiT
+        App
+        App
+        [DataChangeEvent Foo]
+    publishAndConsume events counter
+      `catch` \(_exn :: ConsumptionDone) -> pure ()
     eventsRead <- readIORef counter
     liftIO $ nEvents @=? eventsRead
  where
@@ -68,20 +76,27 @@ testSubscriptionHighLevelProcessing conf = runApp $ do
   nEvents = 10000
 
   publishAndConsume
-    :: (ToJSON a, FromJSON a, Show a) => [DataChangeEvent a] -> IORef Int -> NakadiT App App ()
-  publishAndConsume events counter = bracket before after $ \subscriptionId -> do
-    let n = length events
-    publisherHandle <- async $ delayedPublish Nothing events
-    liftIO $ linkAsync publisherHandle
-    forever $ do
-      subscriptionProcess (Just consumeParameters) subscriptionId
-        $ \(batch :: SubscriptionEventStreamBatch (DataChangeEvent Foo)) -> do
-            let eventsReceived = fromMaybe mempty (batch ^. L.events)
-            modifyIORef counter (+ (length eventsReceived))
-            eventsRead <- readIORef counter
-            when (n <= eventsRead) $ throwIO ConsumptionDone
-      putStrLn $ "Subscription Processing terminated, will restart."
+    :: (ToJSON a, FromJSON a, Show a)
+    => [DataChangeEvent a]
+    -> IORef Int
+    -> NakadiT App App ()
+  publishAndConsume events counter = bracket before after $ \subscriptionId ->
+    do
+      let n = length events
+      publisherHandle <- async $ delayedPublish Nothing events
+      liftIO $ linkAsync publisherHandle
+      forever $ do
+        subscriptionProcess (Just consumeParameters) subscriptionId
+          $ \(batch :: SubscriptionEventStreamBatch (DataChangeEvent Foo)) ->
+              do
+                let eventsReceived = fromMaybe mempty (batch ^. L.events)
+                modifyIORef counter (+ (length eventsReceived))
+                eventsRead <- readIORef counter
+                when (n <= eventsRead) $ throwIO ConsumptionDone
+        putStrLn $ "Subscription Processing terminated, will restart."
 
   consumeParameters =
-    defaultConsumeParameters & setBatchFlushTimeout 1 & setMaxUncommittedEvents 5000 & setBatchLimit
-      10
+    defaultConsumeParameters
+      & setBatchFlushTimeout 1
+      & setMaxUncommittedEvents 5000
+      & setBatchLimit 10

--- a/tests/Network/Nakadi/Subscriptions/Stats/Test.hs
+++ b/tests/Network/Nakadi/Subscriptions/Stats/Test.hs
@@ -10,7 +10,6 @@ import           ClassyPrelude
 
 import           Control.Lens
 import           Data.Aeson
-import           Data.Maybe                     ( fromJust )
 import           Network.Nakadi
 import qualified Network.Nakadi.Lenses         as L
 import           Network.Nakadi.Tests.Common
@@ -65,16 +64,13 @@ testSubscriptionStatsWithTimeLag conf = do
 before :: (MonadUnliftIO m, MonadNakadi App m) => m SubscriptionId
 before = do
   recreateEvent myEventType
-  subscription <- subscriptionCreate Subscription
-    { _id                = Nothing
-    , _owningApplication = "test-suite"
-    , _eventTypes        = [myEventTypeName]
-    , _consumerGroup     = Nothing
-    , _createdAt         = Nothing
-    , _readFrom          = Just SubscriptionPositionBegin
-    , _initialCursors    = Nothing
+  subscription <- subscriptionCreate SubscriptionRequest
+    { _owningApplication    = "test-suite"
+    , _eventTypes           = [myEventTypeName]
+    , _consumerGroup        = Nothing
+    , _subscriptionPosition = Just SubscriptionPositionBegin
     }
-  pure . fromJust $ subscription ^. L.id
+  pure $ subscription ^. L.id
 
 after :: (MonadUnliftIO m, MonadNakadi App m) => SubscriptionId -> m ()
 after subscriptionId = do

--- a/tests/Network/Nakadi/Tests/Common.hs
+++ b/tests/Network/Nakadi/Tests/Common.hs
@@ -123,7 +123,7 @@ recreateEvent :: (MonadUnliftIO m, MonadNakadi b m) => EventType -> m ()
 recreateEvent eventType = do
   let eventTypeName = eventType^.L.name
   subscriptionIds <- subscriptionsList Nothing (Just [eventTypeName])
-    <&> catMaybes . map (view L.id)
+    <&> map (view L.id)
   mapM_ subscriptionDelete subscriptionIds
   eventTypeDelete eventTypeName `catch` (ignoreExnNotFound ())
   eventTypeCreate eventType


### PR DESCRIPTION
closes #103

Introduces a new type `SubscriptionRequest`.
This reorganizes and simplifies the type `Subscription`, most importantly the Subscription ID becomes **mandatory**.

Also, I have simplified (for the user) the handling of the subscription position in these datatypes.
In JSON the subcription position is given by two distinct object fields: read_from and cursors. On the sid of the Haskell API this is now merged in a new ADT SubscriptionPosition. This is a much better modelling of the Nakadi API in my opinion.

Furthermore, a newtype has been added: `ConsumerGroup`.
