### PR TITLE
Event source

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ dependencies:
 - stm
 - unliftio >= 0.2.4.0 && < 0.3
 - async-timer >= 0.2.0.0 && < 0.3
+- stm-chans
 library:
   source-dirs: src
   exposed-modules:

--- a/src/Network/Nakadi/Config.hs
+++ b/src/Network/Nakadi/Config.hs
@@ -147,9 +147,6 @@ setFlowId flowId = L.flowId .~ Just flowId
 setCommitStrategy :: CommitStrategy -> Config m -> Config m
 setCommitStrategy = (L.commitStrategy .~)
 
-setShowTimeLag :: Bool -> Config m -> Config m
-setShowTimeLag flag = L.subscriptionStats ?~ SubscriptionStatsConf {_showTimeLag = flag}
-
 -- | Set maximum number of uncommitted events.
 setMaxUncommittedEvents :: Int32 -> Config m -> Config m
 setMaxUncommittedEvents = (L.maxUncommittedEvents ?~)
@@ -173,3 +170,6 @@ setStreamTimeout = (L.streamTimeout ?~)
 -- | Set stream-keep-alive-limit.
 setStreamKeepAliveLimit :: Int32 -> Config m -> Config m
 setStreamKeepAliveLimit = (L.streamKeepAliveLimit ?~)
+
+setShowTimeLag :: Bool -> Config m -> Config m
+setShowTimeLag flag = L.subscriptionStats ?~ SubscriptionStatsConf {_showTimeLag = flag}

--- a/src/Network/Nakadi/Config.hs
+++ b/src/Network/Nakadi/Config.hs
@@ -30,7 +30,6 @@ module Network.Nakadi.Config
   , setStreamKeepAliveLimit
   , setFlowId
   , setCommitStrategy
-  , defaultConsumeParameters
   , setShowTimeLag
   )
 where
@@ -43,7 +42,6 @@ import           Network.HTTP.Client            ( Manager
                                                 , ManagerSettings
                                                 )
 import           Network.HTTP.Client.TLS        ( newTlsManagerWith )
-import           Network.Nakadi.Internal.Config
 import           Network.Nakadi.Internal.HttpBackendIO
 import qualified Network.Nakadi.Internal.Lenses
                                                as L
@@ -65,8 +63,7 @@ newConfig
   -> Request           -- ^ Request Template
   -> Config b          -- ^ Resulting Configuration
 newConfig httpBackend request = Config
-  { _consumeParameters              = Nothing
-  , _manager                        = Nothing
+  { _manager                        = Nothing
   , _requestTemplate                = request
   , _requestModifier                = pure
   , _deserializationFailureCallback = Nothing
@@ -78,6 +75,12 @@ newConfig httpBackend request = Config
   , _flowId                         = Nothing
   , _commitStrategy                 = defaultCommitStrategy
   , _subscriptionStats              = Nothing
+  , _maxUncommittedEvents           = Nothing
+  , _batchLimit                     = Nothing
+  , _streamLimit                    = Nothing
+  , _batchFlushTimeout              = Nothing
+  , _streamTimeout                  = Nothing
+  , _streamKeepAliveLimit           = Nothing
   }
 
 -- | Producs a new configuration, with mandatory HTTP manager, default
@@ -111,10 +114,8 @@ setRequestModifier = (L.requestModifier .~)
 
 -- | Install a callback in the provided configuration to use in case
 -- of deserialization failures when consuming events.
-setDeserializationFailureCallback
-  :: (ByteString -> Text -> m ()) -> Config m -> Config m
-setDeserializationFailureCallback cb =
-  L.deserializationFailureCallback .~ Just cb
+setDeserializationFailureCallback :: (ByteString -> Text -> m ()) -> Config m -> Config m
+setDeserializationFailureCallback cb = L.deserializationFailureCallback .~ Just cb
 
 -- | Install a callback in the provided configuration which is used
 -- after having successfully established a streaming Nakadi
@@ -146,33 +147,29 @@ setFlowId flowId = L.flowId .~ Just flowId
 setCommitStrategy :: CommitStrategy -> Config m -> Config m
 setCommitStrategy = (L.commitStrategy .~)
 
--- | Set maximum number of uncommitted events in the provided value of
--- consumption parameters.
-setMaxUncommittedEvents :: Int32 -> ConsumeParameters -> ConsumeParameters
-setMaxUncommittedEvents n params = params & L.maxUncommittedEvents .~ Just n
-
--- | Set batch limit in the provided value of consumption parameters.
-setBatchLimit :: Int32 -> ConsumeParameters -> ConsumeParameters
-setBatchLimit n params = params & L.batchLimit .~ Just n
-
--- | Set stream limit in the provided value of consumption parameters.
-setStreamLimit :: Int32 -> ConsumeParameters -> ConsumeParameters
-setStreamLimit n params = params & L.streamLimit .~ Just n
-
--- | Set batch-flush-timeout limit in the provided value of
--- consumption parameters.
-setBatchFlushTimeout :: Int32 -> ConsumeParameters -> ConsumeParameters
-setBatchFlushTimeout n params = params & L.batchFlushTimeout .~ Just n
-
--- | Set stream timeout in the provided value of consumption parameters.
-setStreamTimeout :: Int32 -> ConsumeParameters -> ConsumeParameters
-setStreamTimeout n params = params & L.streamTimeout .~ Just n
-
--- | Set stream-keep-alive-limit in the provided value of consumption
--- parameters.
-setStreamKeepAliveLimit :: Int32 -> ConsumeParameters -> ConsumeParameters
-setStreamKeepAliveLimit n params = params & L.streamKeepAliveLimit .~ Just n
-
 setShowTimeLag :: Bool -> Config m -> Config m
-setShowTimeLag flag =
-  L.subscriptionStats ?~ SubscriptionStatsConf {_showTimeLag = flag}
+setShowTimeLag flag = L.subscriptionStats ?~ SubscriptionStatsConf {_showTimeLag = flag}
+
+-- | Set maximum number of uncommitted events.
+setMaxUncommittedEvents :: Int32 -> Config m -> Config m
+setMaxUncommittedEvents = (L.maxUncommittedEvents ?~)
+
+-- | Set batch limit.
+setBatchLimit :: Int32 -> Config m -> Config m
+setBatchLimit = (L.batchLimit ?~)
+
+-- | Set stream limit.
+setStreamLimit :: Int32 -> Config m -> Config m
+setStreamLimit = (L.streamLimit ?~)
+
+-- | Set batch-flush-timeout limit.
+setBatchFlushTimeout :: Int32 -> Config m -> Config m
+setBatchFlushTimeout = (L.batchFlushTimeout ?~)
+
+-- | Set stream timeout.
+setStreamTimeout :: Int32 -> Config m -> Config m
+setStreamTimeout = (L.streamTimeout ?~)
+
+-- | Set stream-keep-alive-limit.
+setStreamKeepAliveLimit :: Int32 -> Config m -> Config m
+setStreamKeepAliveLimit = (L.streamKeepAliveLimit ?~)

--- a/src/Network/Nakadi/Internal/Config.hs
+++ b/src/Network/Nakadi/Internal/Config.hs
@@ -20,26 +20,12 @@ import           Network.Nakadi.Internal.Prelude
 
 import           Network.Nakadi.Internal.Types
 
-buildConsumeQueryParameters :: ConsumeParameters -> [(ByteString, ByteString)]
-buildConsumeQueryParameters ConsumeParameters { .. } = catMaybes
-  [ ("batch_limit",) . encodeUtf8 . tshow <$> _batchLimit
-  , ("stream_limit",) . encodeUtf8 . tshow <$> _streamLimit
-  , ("batch_flush_timeout",) . encodeUtf8 . tshow <$> _batchFlushTimeout
-  , ("stream_timeout",) . encodeUtf8 . tshow <$> _streamTimeout
-  , ("stream_keep_alive_limit",) . encodeUtf8 . tshow <$> _streamKeepAliveLimit ]
-
-buildSubscriptionConsumeQueryParameters :: ConsumeParameters -> [(ByteString, ByteString)]
-buildSubscriptionConsumeQueryParameters params@ConsumeParameters { .. } =
-  buildConsumeQueryParameters params
-  ++ catMaybes [("max_uncommitted_events",) . encodeUtf8 . tshow <$> _maxUncommittedEvents]
-
--- | Default parameters for event consumption.
-defaultConsumeParameters :: ConsumeParameters
-defaultConsumeParameters = ConsumeParameters
-  { _maxUncommittedEvents = Nothing
-  , _batchLimit           = Nothing
-  , _streamLimit          = Nothing
-  , _batchFlushTimeout    = Nothing
-  , _streamTimeout        = Nothing
-  , _streamKeepAliveLimit = Nothing
-  }
+buildConsumeQueryParameters :: Config m -> [(ByteString, ByteString)]
+buildConsumeQueryParameters Config {..} = catMaybes
+  [ ("batch_limit", ) . encodeUtf8 . tshow <$> _batchLimit
+  , ("stream_limit", ) . encodeUtf8 . tshow <$> _streamLimit
+  , ("batch_flush_timeout", ) . encodeUtf8 . tshow <$> _batchFlushTimeout
+  , ("stream_timeout", ) . encodeUtf8 . tshow <$> _streamTimeout
+  , ("max_uncommitted_events", ) . encodeUtf8 . tshow <$> _maxUncommittedEvents
+  , ("stream_keep_alive_limit", ) . encodeUtf8 . tshow <$> _streamKeepAliveLimit
+  ]

--- a/src/Network/Nakadi/Internal/Lenses.hs
+++ b/src/Network/Nakadi/Internal/Lenses.hs
@@ -55,7 +55,6 @@ makeNakadiLenses ''EventTypeSchemasResponse
 makeNakadiLenses ''PaginationLink
 makeNakadiLenses ''PaginationLinks
 makeNakadiLenses ''SubscriptionStats
-makeNakadiLenses ''ConsumeParameters
 makeNakadiLenses ''SubscriptionCursorCommit
 makeNakadiLenses ''SubscriptionCursor
 makeNakadiLenses ''CursorCommit

--- a/src/Network/Nakadi/Internal/Types/Config.hs
+++ b/src/Network/Nakadi/Internal/Types/Config.hs
@@ -35,32 +35,26 @@ type HttpErrorCallback m = Request -> HttpException -> RetryStatus -> Bool -> m 
 
 type ConfigIO = Config IO
 
-data Config m where
-  Config :: { _requestTemplate                :: Request
-            , _requestModifier                :: Request -> m Request
-            , _manager                        :: Maybe Manager
-            , _consumeParameters              :: Maybe ConsumeParameters
-            , _deserializationFailureCallback :: Maybe (ByteString -> Text -> m ())
-            , _streamConnectCallback          :: Maybe (StreamConnectCallback m)
-            , _logFunc                        :: Maybe (LogFunc m)
-            , _retryPolicy                    :: RetryPolicyM IO
-            , _http                           :: HttpBackend m
-            , _httpErrorCallback              :: Maybe (HttpErrorCallback m)
-            , _flowId                         :: Maybe FlowId
-            , _commitStrategy                 :: CommitStrategy
-            , _subscriptionStats              :: Maybe SubscriptionStatsConf
-            } -> Config m
-
--- | ConsumeParameters
-
-data ConsumeParameters = ConsumeParameters
-  { _maxUncommittedEvents :: Maybe Int32
-  , _batchLimit           :: Maybe Int32
-  , _streamLimit          :: Maybe Int32
-  , _batchFlushTimeout    :: Maybe Int32
-  , _streamTimeout        :: Maybe Int32
-  , _streamKeepAliveLimit :: Maybe Int32
-  } deriving (Show, Eq, Ord)
+data Config m =
+  Config { _requestTemplate                :: Request
+         , _requestModifier                :: Request -> m Request
+         , _manager                        :: Maybe Manager
+         , _deserializationFailureCallback :: Maybe (ByteString -> Text -> m ())
+         , _streamConnectCallback          :: Maybe (StreamConnectCallback m)
+         , _logFunc                        :: Maybe (LogFunc m)
+         , _retryPolicy                    :: RetryPolicyM IO
+         , _http                           :: HttpBackend m
+         , _httpErrorCallback              :: Maybe (HttpErrorCallback m)
+         , _flowId                         :: Maybe FlowId
+         , _commitStrategy                 :: CommitStrategy
+         , _subscriptionStats              :: Maybe SubscriptionStatsConf
+         , _maxUncommittedEvents           :: Maybe Int32
+         , _batchLimit                     :: Maybe Int32
+         , _streamLimit                    :: Maybe Int32
+         , _batchFlushTimeout              :: Maybe Int32
+         , _streamTimeout                  :: Maybe Int32
+         , _streamKeepAliveLimit           :: Maybe Int32
+         }
 
 data HttpBackend b = HttpBackend
   { _httpLbs           :: Config b -> Request -> Maybe Manager -> b (Response LB.ByteString)

--- a/src/Network/Nakadi/Internal/Types/Service.hs
+++ b/src/Network/Nakadi/Internal/Types/Service.hs
@@ -340,6 +340,9 @@ instance FromJSON SubscriptionPosition where
 data ConsumerGroup = ConsumerGroup { unConsumerGroup :: Text }
   deriving (Eq, Ord, Show, Generic, Hashable)
 
+instance IsString ConsumerGroup where
+  fromString = ConsumerGroup . Text.pack
+
 instance ToJSON ConsumerGroup where
   toJSON = String . unConsumerGroup
 

--- a/src/Network/Nakadi/Subscriptions.hs
+++ b/src/Network/Nakadi/Subscriptions.hs
@@ -24,6 +24,8 @@ module Network.Nakadi.Subscriptions
   , subscriptionsList'
   , subscriptionsSource
   , subscriptionsList
+  , withSubscription
+  , withTemporarySubscription
   )
 where
 
@@ -41,6 +43,8 @@ import           Network.Nakadi.Subscriptions.Cursors
 import           Network.Nakadi.Subscriptions.Events
 import           Network.Nakadi.Subscriptions.Stats
 import           Network.Nakadi.Subscriptions.Subscription
+import qualified Data.Set                      as Set
+import           Data.Set                       ( Set )
 
 path :: ByteString
 path = "/subscriptions"
@@ -51,35 +55,24 @@ subscriptionCreate' :: MonadNakadi b m => SubscriptionRequest -> m Subscription
 subscriptionCreate' subscription = httpJsonBody
   status201
   [(ok200, errorSubscriptionExistsAlready)]
-  ( setRequestMethod "POST"
-  . setRequestPath path
-  . setRequestBodyJSON subscription
-  )
+  (setRequestMethod "POST" . setRequestPath path . setRequestBodyJSON subscription)
 
 -- | @POST@ to @\/subscriptions@. Creates a new subscription. Does not
 -- fail if the requested subscription does already exist.
-subscriptionCreate
-  :: (MonadNakadi b m, MonadCatch m) => SubscriptionRequest -> m Subscription
-subscriptionCreate subscription = Safe.catchJust
-  exceptionPredicate
-  (subscriptionCreate' subscription)
-  return
+subscriptionCreate :: (MonadNakadi b m, MonadCatch m) => SubscriptionRequest -> m Subscription
+subscriptionCreate subscription = Safe.catchJust exceptionPredicate
+                                                 (subscriptionCreate' subscription)
+                                                 return
  where
   exceptionPredicate (SubscriptionExistsAlready s) = Just s
   exceptionPredicate _                             = Nothing
 
 -- | @GET@ to @\/subscriptions@. Internal low-level interface.
-subscriptionsGet
-  :: MonadNakadi b m
-  => [(ByteString, ByteString)]
-  -> m SubscriptionsListResponse
+subscriptionsGet :: MonadNakadi b m => [(ByteString, ByteString)] -> m SubscriptionsListResponse
 subscriptionsGet queryParameters = httpJsonBody
   ok200
   []
-  ( setRequestMethod "GET"
-  . setRequestPath path
-  . setRequestQueryParameters queryParameters
-  )
+  (setRequestMethod "GET" . setRequestPath path . setRequestQueryParameters queryParameters)
 
 buildQueryParameters
   :: Maybe ApplicationName
@@ -87,19 +80,15 @@ buildQueryParameters
   -> Maybe Limit
   -> Maybe Offset
   -> [(ByteString, ByteString)]
-buildQueryParameters maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset
-  = catMaybes
-    $  [ ("owning_application", )
-       .   encodeUtf8
-       .   unApplicationName
-       <$> maybeOwningApp
+buildQueryParameters maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset =
+  catMaybes
+    $  [ ("owning_application", ) . encodeUtf8 . unApplicationName <$> maybeOwningApp
        , ("limit", ) . encodeUtf8 . tshow <$> maybeLimit
        , ("offset", ) . encodeUtf8 . tshow <$> maybeOffset
        ]
     ++ case maybeEventTypeNames of
-         Just eventTypeNames -> map
-           (Just . ("event_type", ) . encodeUtf8 . unEventTypeName)
-           eventTypeNames
+         Just eventTypeNames ->
+           map (Just . ("event_type", ) . encodeUtf8 . unEventTypeName) eventTypeNames
          Nothing -> []
 
 -- | @GET@ to @\/subscriptions@. Retrieves all subscriptions matching
@@ -111,13 +100,10 @@ subscriptionsList'
   -> Maybe Limit
   -> Maybe Offset
   -> m SubscriptionsListResponse
-subscriptionsList' maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset =
-  subscriptionsGet queryParameters
+subscriptionsList' maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset = subscriptionsGet
+  queryParameters
  where
-  queryParameters = buildQueryParameters maybeOwningApp
-                                         maybeEventTypeNames
-                                         maybeLimit
-                                         maybeOffset
+  queryParameters = buildQueryParameters maybeOwningApp maybeEventTypeNames maybeLimit maybeOffset
 
 -- | @GET@ to @\/subscriptions@. Retrieves all subscriptions matching
 -- the provided filter criteria. High-level Conduit interface.
@@ -126,28 +112,68 @@ subscriptionsSource
   => Maybe ApplicationName
   -> Maybe [EventTypeName]
   -> m (ConduitM () [Subscription] m ())
-subscriptionsSource maybeOwningApp maybeEventTypeNames = pure
-  $ nextPage initialQueryParameters
+subscriptionsSource maybeOwningApp maybeEventTypeNames = pure $ nextPage initialQueryParameters
  where
   nextPage queryParameters = do
     resp <- lift $ subscriptionsGet queryParameters
     yield (resp ^. L.items)
-    let maybeNextPath =
-          Text.unpack . (view L.href) <$> (resp ^. L.links . L.next)
-    case maybeNextPath >>= extractQueryParametersFromPath of
-      Just nextQueryParameters -> nextPage nextQueryParameters
-      Nothing                  -> return ()
+    let maybeNextPath = Text.unpack . (view L.href) <$> (resp ^. L.links . L.next)
+    forM_ (maybeNextPath >>= extractQueryParametersFromPath) nextPage
 
-  initialQueryParameters =
-    buildQueryParameters maybeOwningApp maybeEventTypeNames Nothing Nothing
+  initialQueryParameters = buildQueryParameters maybeOwningApp maybeEventTypeNames Nothing Nothing
 
 -- | @GET@ to @\/subscriptions@. Retrieves all subscriptions matching
 -- the provided filter criteria. High-level list interface.
 subscriptionsList
-  :: MonadNakadi b m
-  => Maybe ApplicationName
-  -> Maybe [EventTypeName]
-  -> m [Subscription]
+  :: MonadNakadi b m => Maybe ApplicationName -> Maybe [EventTypeName] -> m [Subscription]
 subscriptionsList maybeOwningApp maybeEventTypeNames = do
   source <- subscriptionsSource maybeOwningApp maybeEventTypeNames
   runConduit $ source .| concatC .| sinkList
+
+-- | Experimental API.
+--
+-- Creates a new temporary subscription using the specified parameters via `subscriptionCreate`
+-- and pass it to the provided action. Note that `bracket` is used to enforce the deletion of
+-- the subscription via `subscriptionDelete` when the provided action returns.
+--
+-- Do NOT use this function if the specified subscription should not be deleted.
+withTemporarySubscription
+  :: (MonadNakadi b m, MonadMask m)
+  => ApplicationName
+  -> ConsumerGroup
+  -> Set EventTypeName
+  -> SubscriptionPosition
+  -> (Subscription -> m r)
+  -> m r
+withTemporarySubscription owningApp consumerGroup eventTypeNames subscriptionPosition = bracket
+  (subscriptionCreate subscriptionRequest)
+  (subscriptionDelete . view L.id)
+ where
+  subscriptionRequest = SubscriptionRequest
+    { _owningApplication    = owningApp
+    , _eventTypes           = Set.toList eventTypeNames
+    , _consumerGroup        = Just consumerGroup
+    , _subscriptionPosition = Just subscriptionPosition
+    }
+
+-- | Experimental API.
+--
+-- Creates a new subscription using the specified parameters via `subscriptionCreate`
+-- and pass it to the provided action.
+withSubscription
+  :: (MonadNakadi b m, MonadMask m)
+  => ApplicationName
+  -> ConsumerGroup
+  -> Set EventTypeName
+  -> SubscriptionPosition
+  -> (Subscription -> m r)
+  -> m r
+withSubscription owningApp consumerGroup eventTypeNames subscriptionPosition f =
+  subscriptionCreate subscriptionRequest >>= f
+ where
+  subscriptionRequest = SubscriptionRequest
+    { _owningApplication    = owningApp
+    , _eventTypes           = Set.toList eventTypeNames
+    , _consumerGroup        = Just consumerGroup
+    , _subscriptionPosition = Just subscriptionPosition
+    }

--- a/src/Network/Nakadi/Subscriptions/Events.hs
+++ b/src/Network/Nakadi/Subscriptions/Events.hs
@@ -22,33 +22,48 @@ This module implements a high level interface for the
 module Network.Nakadi.Subscriptions.Events
   ( subscriptionProcessConduit
   , subscriptionProcess
-  ) where
+  , subscriptionSource
+  , subscriptionSourceEvents
+  )
+where
 
 import           Network.Nakadi.Internal.Prelude
 
-import           Conduit                              hiding (throwM)
-import qualified Control.Concurrent.Async.Timer       as Timer
-import           Control.Concurrent.STM               (TBQueue, TVar,
-                                                       atomically, modifyTVar,
-                                                       newTBQueue, newTVar,
-                                                       readTBQueue, readTVar,
-                                                       retry, swapTVar,
-                                                       writeTBQueue)
+import           UnliftIO.STM                   ( TBQueue
+                                                , TVar
+                                                , atomically
+                                                , newTBQueue
+                                                , writeTBQueue
+                                                , readTBQueue
+                                                , modifyTVar
+                                                , newTVar
+                                                , readTVar
+                                                , swapTVar
+                                                )
+
+import           Conduit                 hiding ( throwM )
+import qualified Control.Concurrent.Async.Timer
+                                               as Timer
+import           Control.Concurrent.STM         ( retry )
 import           Control.Lens
 import           Control.Monad.Logger
 import           Data.Aeson
-import qualified Data.Conduit.List                    as Conduit (mapM_)
-import           Data.HashMap.Strict                  (HashMap)
-import qualified Data.HashMap.Strict                  as HashMap
-import qualified Data.Vector                          as Vector
-import           Network.HTTP.Client                  (responseBody)
+import qualified Data.Conduit.List             as Conduit
+                                                ( mapM_ )
+import           Data.HashMap.Strict            ( HashMap )
+import qualified Data.HashMap.Strict           as HashMap
+import qualified Data.Vector                   as Vector
+import           Network.HTTP.Client            ( responseBody )
 import           Network.HTTP.Simple
 import           Network.HTTP.Types
 import           Network.Nakadi.Internal.Config
 import           Network.Nakadi.Internal.Conversions
 import           Network.Nakadi.Internal.Http
-import qualified Network.Nakadi.Internal.Lenses       as L
+import qualified Network.Nakadi.Internal.Lenses
+                                               as L
 import           Network.Nakadi.Subscriptions.Cursors
+import           Network.Nakadi.Config
+
 import           UnliftIO.Async
 
 -- | Consumes the specified subscription using the commit strategy
@@ -56,17 +71,16 @@ import           UnliftIO.Async
 -- events is provided to the provided batch processor action. If this
 -- action throws an exception, subscription consumption will terminate.
 subscriptionProcess
-  :: ( MonadNakadi b m
-     , MonadUnliftIO m
-     , MonadMask m
-     , FromJSON a )
+  :: (MonadNakadi b m, MonadUnliftIO m, MonadMask m, FromJSON a)
   => Maybe ConsumeParameters                  -- ^ 'ConsumeParameters'
                                               -- to use
   -> SubscriptionId                           -- ^ Subscription to consume
   -> (SubscriptionEventStreamBatch a -> m ()) -- ^ Batch processor action
   -> m ()
-subscriptionProcess maybeConsumeParameters subscriptionId processor =
-  subscriptionProcessConduit maybeConsumeParameters subscriptionId conduit
+subscriptionProcess maybeConsumeParameters subscriptionId processor = subscriptionProcessConduit
+  maybeConsumeParameters
+  subscriptionId
+  conduit
   where conduit = iterMC processor
 
 -- | Conduit based interface for subscription consumption. Consumes
@@ -79,7 +93,8 @@ subscriptionProcessConduit
      , MonadUnliftIO m
      , MonadMask m
      , FromJSON a
-     , batch ~ SubscriptionEventStreamBatch a )
+     , batch ~ SubscriptionEventStreamBatch a
+     )
   => Maybe ConsumeParameters   -- ^ 'ConsumeParameters' to use
   -> SubscriptionId            -- ^ Subscription to consume
   -> ConduitM batch batch m () -- ^ Conduit processor.
@@ -88,31 +103,24 @@ subscriptionProcessConduit maybeConsumeParameters subscriptionId processor = do
   config <- nakadiAsk
   let consumeParams = fromMaybe defaultConsumeParameters maybeConsumeParameters
       queryParams   = buildSubscriptionConsumeQueryParameters consumeParams
-  httpJsonBodyStream ok200 [(status404, errorSubscriptionNotFound)]
-    (includeFlowId config
-     . setRequestPath path
-     . setRequestQueryParameters queryParams) $
-    subscriptionProcessHandler consumeParams subscriptionId processor
-
-  where path = "/subscriptions/"
-               <> subscriptionIdToByteString subscriptionId
-               <> "/events"
+  httpJsonBodyStream
+      ok200
+      [(status404, errorSubscriptionNotFound)]
+      (includeFlowId config . setRequestPath path . setRequestQueryParameters queryParams)
+    $ subscriptionProcessHandler consumeParams subscriptionId processor
+  where path = "/subscriptions/" <> subscriptionIdToByteString subscriptionId <> "/events"
 
 -- | Derive a 'SubscriptionEventStream' from the provided
 -- 'SubscriptionId' and Nakadi streaming response.
 buildSubscriptionEventStream
-  :: MonadThrow m
-  => SubscriptionId
-  -> Response a
-  -> m SubscriptionEventStream
+  :: MonadThrow m => SubscriptionId -> Response a -> m SubscriptionEventStream
 buildSubscriptionEventStream subscriptionId response =
   case listToMaybe (getResponseHeader "X-Nakadi-StreamId" response) of
-    Just streamId ->
-      pure SubscriptionEventStream
+    Just streamId -> pure SubscriptionEventStream
       { _streamId       = StreamId (decodeUtf8 streamId)
-      , _subscriptionId = subscriptionId }
-    Nothing ->
-      throwM StreamIdMissing
+      , _subscriptionId = subscriptionId
+      }
+    Nothing -> throwM StreamIdMissing
 
 -- | This function processes a subscription, taking care of applying
 -- the configured committing strategy.
@@ -121,7 +129,8 @@ subscriptionProcessHandler
      , MonadUnliftIO m
      , MonadMask m
      , FromJSON a
-     , batch ~ (SubscriptionEventStreamBatch a) )
+     , batch ~ (SubscriptionEventStreamBatch a)
+     )
   => ConsumeParameters
   -> SubscriptionId                         -- ^ Subscription ID required for committing.
   -> ConduitM batch batch m ()              -- ^ User provided Conduit for stream.
@@ -130,11 +139,8 @@ subscriptionProcessHandler
 subscriptionProcessHandler consumeParams subscriptionId processor response = do
   config      <- nakadiAsk
   eventStream <- buildSubscriptionEventStream subscriptionId response
-  let producer = responseBody response
-                 .| linesUnboundedAsciiC
-                 .| conduitDecode config
-                 .| processor
-  case config^.L.commitStrategy of
+  let producer = responseBody response .| linesUnboundedAsciiC .| conduitDecode config .| processor
+  case config ^. L.commitStrategy of
     CommitSync ->
       -- Synchronous case: Simply use a Conduit sink that commits
       -- every cursor.
@@ -146,17 +152,17 @@ subscriptionProcessHandler consumeParams subscriptionId processor response = do
       -- sink that sends cursor information to the queue. The cursor
       -- committer thread reads from this queue and processes the
       -- cursors.
-      queue <- liftIO . atomically $ newTBQueue 1024
-      withAsync (subscriptionCommitter bufferingStrategy consumeParams eventStream queue) $
-        \ asyncHandle -> do
-          link asyncHandle
-          runConduit $ producer .| Conduit.mapM_ (sendToQueue queue)
-
-  where sendToQueue queue batch = liftIO . atomically $ do
-          let cursor  = batch^.L.cursor
-              events  = fromMaybe Vector.empty (batch^.L.events)
-              nEvents = length events
-          writeTBQueue queue (nEvents, cursor)
+      queue <- atomically $ newTBQueue 1024
+      withAsync (subscriptionCommitter bufferingStrategy consumeParams eventStream queue)
+        $ \asyncHandle -> do
+            link asyncHandle
+            runConduit $ producer .| Conduit.mapM_ (sendToQueue queue)
+ where
+  sendToQueue queue batch = atomically $ do
+    let cursor  = batch ^. L.cursor
+        events  = fromMaybe Vector.empty (batch ^. L.events)
+        nEvents = length events
+    writeTBQueue queue (nEvents, cursor)
 
 -- | Sink which can be used as sink for Conduits processing
 -- subscriptions events. This sink takes care of committing events. It
@@ -167,14 +173,16 @@ subscriptionSink
   -> ConduitM (SubscriptionEventStreamBatch a) void m ()
 subscriptionSink eventStream = do
   config <- lift nakadiAsk
-  awaitForever $ \ batch -> lift $ do
-    let cursor  = batch^.L.cursor
-    catchAny (commitOneCursor eventStream cursor) $ \ exn -> nakadiLiftBase $
-      case config^.L.logFunc of
-        Just logFunc -> logFunc "nakadi-client" LevelWarn $ toLogStr $
-          "Failed to synchronously commit cursor: " <> tshow exn
-        Nothing ->
-          pure ()
+  awaitForever $ \batch -> lift $ do
+    let cursor = batch ^. L.cursor
+    catchAny (commitOneCursor eventStream cursor) $ \exn ->
+      nakadiLiftBase $ case config ^. L.logFunc of
+        Just logFunc ->
+          logFunc "nakadi-client" LevelWarn
+            $  toLogStr
+            $  "Failed to synchronously commit cursor: "
+            <> tshow exn
+        Nothing -> pure ()
 
 type CursorsMap = HashMap (EventTypeName, PartitionName) (Int, SubscriptionCursor)
 
@@ -182,7 +190,7 @@ emptyCursorsMap :: CursorsMap
 emptyCursorsMap = HashMap.empty
 
 cursorKey :: SubscriptionCursor -> (EventTypeName, PartitionName)
-cursorKey cursor = (cursor^.L.eventType, cursor^.L.partition)
+cursorKey cursor = (cursor ^. L.eventType, cursor ^. L.partition)
 
 -- | Implementation for the 'CommitNoBuffer' strategy: We simply read
 -- every cursor and commit it in order.
@@ -194,32 +202,28 @@ unbufferedCommitLoop
 unbufferedCommitLoop eventStream queue = do
   config <- nakadiAsk
   forever $ do
-    (_nEvents, cursor) <- liftIO . atomically . readTBQueue $ queue
-    catchAny (subscriptionCursorCommit eventStream [cursor]) $ \ exn -> do
-      nakadiLiftBase $
-        case config^.L.logFunc of
-          Just logFunc -> logFunc "nakadi-client" LevelWarn $ toLogStr $
-            "Failed to commit cursor " <> tshow cursor <> ": " <> tshow exn
-          Nothing ->
-            pure ()
+    (_nEvents, cursor) <- atomically . readTBQueue $ queue
+    catchAny (subscriptionCursorCommit eventStream [cursor]) $ \exn -> do
+      nakadiLiftBase $ case config ^. L.logFunc of
+        Just logFunc ->
+          logFunc "nakadi-client" LevelWarn
+            $  toLogStr
+            $  "Failed to commit cursor "
+            <> tshow cursor
+            <> ": "
+            <> tshow exn
+        Nothing -> pure ()
 
 cursorBufferSize :: ConsumeParameters -> Int
-cursorBufferSize consumeParams =
-  case consumeParams^.L.maxUncommittedEvents of
-    Nothing -> 1
-    Just n  -> n
-               & fromIntegral
-               & (* safetyFactor)
-               & round
-
-  where safetyFactor     = 0.5
+cursorBufferSize consumeParams = case consumeParams ^. L.maxUncommittedEvents of
+  Nothing -> 1
+  Just n  -> n & fromIntegral & (* safetyFactor) & round
+  where safetyFactor = 0.5
 
 -- | Main function for the cursor committer thread. Logic depends on
 -- the provided buffering strategy.
 subscriptionCommitter
-  :: ( MonadNakadi b m
-     , MonadUnliftIO m
-     , MonadMask m )
+  :: (MonadNakadi b m, MonadUnliftIO m, MonadMask m)
   => CommitBufferingStrategy
   -> ConsumeParameters
   -> SubscriptionEventStream
@@ -234,21 +238,19 @@ subscriptionCommitter CommitNoBuffer _consumeParams eventStream queue =
 -- | Implementation of the 'CommitTimeBuffer' strategy: We use an
 -- async timer for committing cursors at specified intervals.
 subscriptionCommitter (CommitTimeBuffer millis) _consumeParams eventStream queue = do
-  let timerConf = Timer.defaultConf
-                  & Timer.setInitDelay (fromIntegral millis)
-                  & Timer.setInterval  (fromIntegral millis)
+  let timerConf = Timer.defaultConf & Timer.setInitDelay (fromIntegral millis) & Timer.setInterval
+        (fromIntegral millis)
   cursorsMap <- liftIO . atomically $ newTVar emptyCursorsMap
-  withAsync (cursorConsumer cursorsMap) $ \ asyncCursorConsumer -> do
+  withAsync (cursorConsumer cursorsMap) $ \asyncCursorConsumer -> do
     link asyncCursorConsumer
-    Timer.withAsyncTimer timerConf $ \ timer -> forever $ do
+    Timer.withAsyncTimer timerConf $ \timer -> forever $ do
       Timer.wait timer
       commitAllCursors eventStream cursorsMap
-
-  where -- | The cursorsConsumer drains the cursors queue and adds each
+ where -- | The cursorsConsumer drains the cursors queue and adds each
         -- cursor to the provided cursorsMap.
-        cursorConsumer cursorsMap = forever . liftIO . atomically $ do
-          (_, cursor) <- readTBQueue queue
-          modifyTVar cursorsMap (HashMap.insert (cursorKey cursor) (0, cursor))
+  cursorConsumer cursorsMap = forever . liftIO . atomically $ do
+    (_, cursor) <- readTBQueue queue
+    modifyTVar cursorsMap (HashMap.insert (cursorKey cursor) (0, cursor))
 
 -- | Implementation of the 'CommitSmartBuffer' strategy: We use an
 -- async timer for committing cursors at specified intervals, but if
@@ -256,33 +258,34 @@ subscriptionCommitter (CommitTimeBuffer millis) _consumeParams eventStream queue
 -- next scheduled commit, a commit is being done right away and the
 -- timer is resetted.
 subscriptionCommitter CommitSmartBuffer consumeParams eventStream queue = do
-  let millisDefault = 1000
-      nMaxEvents    = cursorBufferSize consumeParams
-      timerConf     = Timer.defaultConf
-                      & Timer.setInitDelay (fromIntegral millisDefault)
-                      & Timer.setInterval  (fromIntegral millisDefault)
+  let
+    millisDefault = 1000
+    nMaxEvents    = cursorBufferSize consumeParams
+    timerConf =
+      Timer.defaultConf & Timer.setInitDelay (fromIntegral millisDefault) & Timer.setInterval
+        (fromIntegral millisDefault)
   if nMaxEvents > 1
-    then do cursorsMap <- liftIO . atomically $ newTVar emptyCursorsMap
-            withAsync (cursorConsumer cursorsMap) $ \ asyncCursorConsumer -> do
-              link asyncCursorConsumer
-              Timer.withAsyncTimer timerConf $ cursorCommitter cursorsMap nMaxEvents
+    then do
+      cursorsMap <- liftIO . atomically $ newTVar emptyCursorsMap
+      withAsync (cursorConsumer cursorsMap) $ \asyncCursorConsumer -> do
+        link asyncCursorConsumer
+        Timer.withAsyncTimer timerConf $ cursorCommitter cursorsMap nMaxEvents
     else unbufferedCommitLoop eventStream queue
-
-  where -- | The cursorsConsumer drains the cursors queue and adds
+ where -- | The cursorsConsumer drains the cursors queue and adds
         -- each cursor to the provided cursorsMap.
-        cursorConsumer cursorsMap = forever . liftIO . atomically $ do
-          (nEvents, cursor) <- readTBQueue queue
-          modifyTVar cursorsMap $
-            HashMap.insertWith updateCursor (cursorKey cursor) (nEvents, cursor)
+  cursorConsumer cursorsMap = forever . liftIO . atomically $ do
+    (nEvents, cursor) <- readTBQueue queue
+    modifyTVar cursorsMap $ HashMap.insertWith updateCursor (cursorKey cursor) (nEvents, cursor)
 
-        -- | Adds the old number of events to the new entry in the
-        -- cursors map.
-        updateCursor cursorNew _cursorOld @ (nEventsOld, _) =
-          cursorNew & _1 %~ (+ nEventsOld)
+  -- | Adds the old number of events to the new entry in the
+  -- cursors map.
+  updateCursor cursorNew (nEventsOld, _) = cursorNew & _1 %~ (+ nEventsOld)
 
-        -- | Committer loop.
-        cursorCommitter cursorsMap nMaxEvents timer = forever $  do
-          race (Timer.wait timer) (maxEventsReached cursorsMap nMaxEvents) >>= \ case
+  -- | Committer loop.
+  cursorCommitter cursorsMap nMaxEvents timer =
+    forever
+      $   race (Timer.wait timer) (maxEventsReached cursorsMap nMaxEvents)
+      >>= \case
             Left _ ->
               -- Timer has elapsed, simply commit all currently
               -- buffered cursors.
@@ -294,43 +297,74 @@ subscriptionCommitter CommitSmartBuffer consumeParams eventStream queue = do
               Timer.reset timer
               commitAllCursors eventStream cursorsMap
 
-        -- | Returns list of cursors that should be committed
-        -- considering the number of events processed on the
-        -- respective partition since the last commit. Blocks until at
-        -- least one such cursor is found.
-        maxEventsReached cursorsMap nMaxEvents = liftIO . atomically $ do
-          cursorsList <- HashMap.toList <$> readTVar cursorsMap
-          let cursorsCommit = filter (shouldBeCommitted nMaxEvents) cursorsList
-          if null cursorsCommit
-            then retry
-            else pure ()
+  -- | Returns list of cursors that should be committed
+  -- considering the number of events processed on the
+  -- respective partition since the last commit. Blocks until at
+  -- least one such cursor is found.
+  maxEventsReached cursorsMap nMaxEvents = liftIO . atomically $ do
+    cursorsList <- HashMap.toList <$> readTVar cursorsMap
+    let cursorsCommit = filter (shouldBeCommitted nMaxEvents) cursorsList
+    if null cursorsCommit then retry else pure ()
 
-        -- | Returns True if the provided cursor should be committed.
-        shouldBeCommitted nMaxEvents cursor = cursor^._2._1  >= nMaxEvents
+  -- | Returns True if the provided cursor should be committed.
+  shouldBeCommitted nMaxEvents cursor = cursor ^. _2 . _1 >= nMaxEvents
 
 -- | This function commits all cursors in the provided cursorsMap.
 commitAllCursors
-  :: (MonadNakadi b m, MonadIO m)
-  => SubscriptionEventStream
-  -> TVar CursorsMap
-  -> m ()
+  :: (MonadNakadi b m, MonadIO m) => SubscriptionEventStream -> TVar CursorsMap -> m ()
 commitAllCursors eventStream cursorsMap = do
   cursors <- liftIO . atomically $ swapTVar cursorsMap emptyCursorsMap
-  forM_ cursors $ \ (_nEvents, cursor) -> commitOneCursor eventStream cursor
+  forM_ cursors $ \(_nEvents, cursor) -> commitOneCursor eventStream cursor
 
 -- | This function takes care of committing a single cursor. Exceptions will be
 -- catched and logged, but the failure will NOT be propagated. This means that
 -- Nakadi itself is in control of disconnecting us.
 commitOneCursor
-  :: (MonadIO m, MonadNakadi b m)
-  => SubscriptionEventStream
-  -> SubscriptionCursor
-  -> m ()
+  :: (MonadIO m, MonadNakadi b m) => SubscriptionEventStream -> SubscriptionCursor -> m ()
 commitOneCursor eventStream cursor = do
   config <- nakadiAsk
-  catchAny (subscriptionCursorCommit eventStream [cursor]) $ \ exn -> nakadiLiftBase $
-    case config^.L.logFunc of
-      Just logFunc -> logFunc "nakadi-client" LevelWarn $ toLogStr $
-        "Failed to commit cursor " <> tshow cursor <> ": " <> tshow exn
-      Nothing ->
-        pure ()
+  catchAny (subscriptionCursorCommit eventStream [cursor])
+    $ \exn -> nakadiLiftBase $ case config ^. L.logFunc of
+        Just logFunc ->
+          logFunc "nakadi-client" LevelWarn
+            $  toLogStr
+            $  "Failed to commit cursor "
+            <> tshow cursor
+            <> ": "
+            <> tshow exn
+        Nothing -> pure ()
+
+-- | Experimental API.
+--
+-- Creates a Conduit source from a subscription ID. The source will produce subscription
+-- event stream batches. Note the batches will be asynchronously committed irregardless of
+-- any event processing logic. Use this function only if the guarantees provided by Nakadi
+-- for event processing and cursor committing are not required or not desired.
+subscriptionSource
+  :: (MonadNakadi b m, MonadUnliftIO m, MonadMask m, FromJSON a)
+  => SubscriptionId                                    -- ^ Subscription to consume.
+  -> ConduitM () (SubscriptionEventStreamBatch a) m () -- ^ Conduit source.
+subscriptionSource subscriptionId = do
+  queue <- atomically $ newTBQueue queueSize
+  void
+    . lift
+    . async
+    $ subscriptionProcess (Just consumeParams) subscriptionId
+    $ void
+    . atomically
+    . writeTBQueue queue
+  forever $ atomically (readTBQueue queue) >>= yield
+ where
+  consumeParams = defaultConsumeParameters & setBatchFlushTimeout 1
+  queueSize     = 2048
+
+-- | Experimental API.
+
+-- Similar to `subscriptionSource`, but the created Conduit source provides events instead
+-- of event batches.
+subscriptionSourceEvents
+  :: (MonadNakadi b m, MonadUnliftIO m, MonadMask m, FromJSON a)
+  => SubscriptionId     -- ^ Subscription to consume
+  -> ConduitM () a m () -- ^ Conduit processor.
+subscriptionSourceEvents subscriptionId =
+  subscriptionSource subscriptionId .| concatMapC (\batch -> fromMaybe mempty (batch & _events))

--- a/src/Network/Nakadi/Types/Config.hs
+++ b/src/Network/Nakadi/Types/Config.hs
@@ -13,7 +13,6 @@ This module provides the Nakadi Config Types.
 module Network.Nakadi.Types.Config
   ( Config
   , ConfigIO
-  , ConsumeParameters
   , StreamConnectCallback
   , HttpBackend(..)
   ) where

--- a/src/Network/Nakadi/Types/Service.hs
+++ b/src/Network/Nakadi/Types/Service.hs
@@ -36,6 +36,7 @@ module Network.Nakadi.Types.Service
   , SubscriptionPosition(..)
   , Subscription(..)
   , SubscriptionRequest(..)
+  , ConsumerGroup(..)
   , PublishingStatus(..)
   , Step(..)
   , BatchItemResponse(..)
@@ -72,6 +73,6 @@ module Network.Nakadi.Types.Service
   , EventTypeStatistics(..)
   , EventTypeOptions(..)
   )
-where
+  where
 
 import           Network.Nakadi.Internal.Types.Service

--- a/tests/Network/Nakadi/EventTypes/BusinessEvents/Test.hs
+++ b/tests/Network/Nakadi/EventTypes/BusinessEvents/Test.hs
@@ -15,8 +15,6 @@ import           System.Random
 import           Control.Lens
 import qualified Data.Set                      as Set
 import           Data.Aeson
-import           UnliftIO.Async                 ( async )
-import           Control.Monad.Catch            ( MonadMask )
 
 import           Conduit
 

--- a/tests/Network/Nakadi/Examples/Subscription/Process.hs
+++ b/tests/Network/Nakadi/Examples/Subscription/Process.hs
@@ -12,7 +12,7 @@ import Control.Monad.Catch (MonadMask)
 dumpSubscription :: (MonadLogger m, MonadNakadi IO m, MonadUnliftIO m, MonadMask m)
                  => Nakadi.SubscriptionId -> m ()
 dumpSubscription subscriptionId =
-  Nakadi.subscriptionProcess Nothing subscriptionId processBatch
+  Nakadi.subscriptionProcess subscriptionId processBatch
 
   where processBatch :: MonadLogger m => Nakadi.SubscriptionEventStreamBatch Value -> m ()
         processBatch batch =

--- a/tests/Network/Nakadi/Subscriptions/Stats/Test.hs
+++ b/tests/Network/Nakadi/Subscriptions/Stats/Test.hs
@@ -35,7 +35,6 @@ produceSubscriptionStats conf =
     -- Note: Apparently we have to consume the subscription first in order to enable
     -- tracking of unconsumed events and time lag.
         void $ timeout (2 * 10 ^ (6 :: Int)) $ subscriptionProcess
-          Nothing
           subscriptionId
           (\(_batch :: SubscriptionEventStreamBatch (DataChangeEvent Value)) ->
             pure ()


### PR DESCRIPTION
Implement simply event sourcing.

Up for discussion, probably requires some improvements.

This PR also removes the weirdness of the previous subscriptionProcess API where a ConsumeParameters value had to be provided. This is now implicit in the main configuration.
