### PR TITLE
Fixed a comment which is tripping hoogle

### DIFF
--- a/src/Network/Nakadi/Internal/Committer/TimeBuffer.hs
+++ b/src/Network/Nakadi/Internal/Committer/TimeBuffer.hs
@@ -46,7 +46,7 @@ committerTimeBuffer millis eventStream queue = do
     Timer.withAsyncTimer timerConf $ \timer -> forever $ do
       Timer.wait timer
       commitAllCursors identity eventStream cursorsMap
- where -- | The cursorsConsumer drains the cursors queue and adds each
+ where -- The cursorsConsumer drains the cursors queue and adds each
        -- cursor to the provided cursorsMap.
   cursorConsumer cursorsMap = forever . liftIO . atomically $ do
     (_, cursor) <- readTBQueue queue


### PR DESCRIPTION
with a parse error
```haskell
src/Network/Nakadi/Internal/Committer/TimeBuffer.hs:51:3: error:
        parse error on input ‘cursorConsumer’
       |
    51 |   cursorConsumer cursorsMap = forever . liftIO . atomically $ do
       |   ^^^^^^^^^^^^^^
```