### PR TITLE
Make consumption function return Void

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Nakadi-Client Change Log
 
+## v0.8.0.0
+
+* Connections closed by Nakadi will throw a `ConsumptionInterrupted`.
+
+* Subscription related functions (e.g. `subscriptionProcess`) have `Void` return types to signal that they are not expected to terminate.
+
 ## v0.6.0.0
 
 * Nakadi *business events* are supported.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Subscription related functions (e.g. `subscriptionProcess`) have `Void` return types to signal that they are not expected to terminate.
 
+* `streamLimit` config option is no longer supported as it no longer makes sense with the above changes.
+
 ## v0.6.0.0
 
 * Nakadi *business events* are supported.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: nakadi-client
-version: '0.7.0.0'
+version: '0.8.0.0'
 synopsis: Client library for the Nakadi Event Broker
 description: This package implements a client library for interacting
              with the Nakadi event broker system developed by Zalando.

--- a/src/Network/Nakadi/Config.hs
+++ b/src/Network/Nakadi/Config.hs
@@ -26,7 +26,6 @@ module Network.Nakadi.Config
   , setWorkerThreads
   , setMaxUncommittedEvents
   , setBatchLimit
-  , setStreamLimit
   , setBatchFlushTimeout
   , setStreamTimeout
   , setStreamKeepAliveLimit
@@ -132,10 +131,6 @@ setMaxUncommittedEvents = (L.maxUncommittedEvents ?~)
 -- | Set batch limit.
 setBatchLimit :: Int32 -> Config m -> Config m
 setBatchLimit = (L.batchLimit ?~)
-
--- | Set stream limit.
-setStreamLimit :: Int32 -> Config m -> Config m
-setStreamLimit = (L.streamLimit ?~)
 
 -- | Set batch-flush-timeout limit.
 setBatchFlushTimeout :: Int32 -> Config m -> Config m

--- a/src/Network/Nakadi/Internal/Config.hs
+++ b/src/Network/Nakadi/Internal/Config.hs
@@ -28,7 +28,6 @@ import           Network.Nakadi.Internal.Types
 buildConsumeQueryParameters :: Config m -> [(ByteString, ByteString)]
 buildConsumeQueryParameters Config {..} = catMaybes
   [ ("batch_limit", ) . encodeUtf8 . tshow <$> _batchLimit
-  , ("stream_limit", ) . encodeUtf8 . tshow <$> _streamLimit
   , ("batch_flush_timeout", ) . encodeUtf8 . tshow <$> _batchFlushTimeout
   , ("stream_timeout", ) . encodeUtf8 . tshow <$> _streamTimeout
   , ("max_uncommitted_events", ) . encodeUtf8 . tshow <$> _maxUncommittedEvents
@@ -75,7 +74,6 @@ newConfig httpBackend request = Config { _manager                        = Nothi
                                        , _subscriptionStats              = Nothing
                                        , _maxUncommittedEvents           = Nothing
                                        , _batchLimit                     = Nothing
-                                       , _streamLimit                    = Nothing
                                        , _batchFlushTimeout              = Nothing
                                        , _streamTimeout                  = Nothing
                                        , _streamKeepAliveLimit           = Nothing

--- a/src/Network/Nakadi/Internal/Types/Config.hs
+++ b/src/Network/Nakadi/Internal/Types/Config.hs
@@ -51,7 +51,6 @@ data Config m =
          , _subscriptionStats              :: Maybe SubscriptionStatsConf
          , _maxUncommittedEvents           :: Maybe Int32
          , _batchLimit                     :: Maybe Int32
-         , _streamLimit                    :: Maybe Int32
          , _batchFlushTimeout              :: Maybe Int32
          , _streamTimeout                  :: Maybe Int32
          , _streamKeepAliveLimit           :: Maybe Int32

--- a/src/Network/Nakadi/Internal/Types/Exceptions.hs
+++ b/src/Network/Nakadi/Internal/Types/Exceptions.hs
@@ -41,7 +41,7 @@ data NakadiException = BatchPartiallySubmitted [BatchItemResponse]
                      | StreamIdMissing
                      | NakadiUrlMissing
                      | ConfigurationMissing
-                     | ConsumptionStoppedException -- ^ is thrown when Nakadi closes the connection. Once you start consuming an event/subscription it should not terminate, but Nakadi will occasionally close the connection.
+                     | ConsumptionInterrupted -- ^ Thrown when Nakadi closes the connection. Once you start consuming an event/subscription it should not terminate, but Nakadi will occasionally close the connection.
                      deriving (Show, Typeable)
 
 instance Exception NakadiException

--- a/src/Network/Nakadi/Internal/Types/Exceptions.hs
+++ b/src/Network/Nakadi/Internal/Types/Exceptions.hs
@@ -41,6 +41,7 @@ data NakadiException = BatchPartiallySubmitted [BatchItemResponse]
                      | StreamIdMissing
                      | NakadiUrlMissing
                      | ConfigurationMissing
+                     | ConsumptionStoppedException -- ^ is thrown when Nakadi closes the connection. Once you start consuming an event/subscription it should not terminate, but Nakadi will occasionally close the connection.
                      deriving (Show, Typeable)
 
 instance Exception NakadiException

--- a/src/Network/Nakadi/Subscriptions/Events.hs
+++ b/src/Network/Nakadi/Subscriptions/Events.hs
@@ -147,7 +147,7 @@ subscriptionProcessHandler subscriptionId processor response = do
     .| conduitDecode
     .| mapC (identity :: batch -> batch)
     .| workerDispatchSink workerRegistry
-  throwM ConsumptionStoppedException
+  throwM ConsumptionInterrupted
 
 -- | Experimental API.
 --

--- a/tests/Network/Nakadi/EventTypes/BusinessEvents/Test.hs
+++ b/tests/Network/Nakadi/EventTypes/BusinessEvents/Test.hs
@@ -127,7 +127,7 @@ publishAndConsume conf' eventSpec =
         liftIO
           $   map (eventPayload eventSpec)         events
           @=? map (eventEnrichedPayload eventSpec) consumed
-  where conf = conf' & setBatchFlushTimeout 1 & setStreamLimit 10
+  where conf = conf' & setBatchFlushTimeout 1
 
 createAndDeleteEvent :: Config App -> EventSpec a b c -> Assertion
 createAndDeleteEvent conf eventSpec =

--- a/tests/Network/Nakadi/EventTypes/Test.hs
+++ b/tests/Network/Nakadi/EventTypes/Test.hs
@@ -10,6 +10,7 @@ import           ClassyPrelude           hiding ( withAsync )
 
 import           Control.Lens
 import           Data.Function                  ( (&) )
+import           Data.Void
 import           Network.Nakadi
 import           Network.Nakadi.EventTypes.CursorsLag.Test
 import           Network.Nakadi.EventTypes.ShiftedCursors.Test
@@ -198,7 +199,7 @@ testEventTypeDeserializationFailureException conf' = runApp . runNakadiT conf $ 
         , _dataOp   = DataOpUpdate
         }
   subscriptionId                   <- createMySubscription
-  res :: Either NakadiException () <-
+  res :: Either NakadiException Void <-
     try $ withAsync (delayedPublish Nothing [event]) $ \asyncHandle -> do
       liftIO $ link asyncHandle
       runResourceT

--- a/tests/Network/Nakadi/Examples/Subscription/Process.hs
+++ b/tests/Network/Nakadi/Examples/Subscription/Process.hs
@@ -7,6 +7,7 @@ where
 
 import           ClassyPrelude
 import           Data.Aeson
+import           Data.Void
 import qualified Network.Nakadi                as Nakadi
 import           Network.Nakadi                 ( MonadNakadi )
 import           Control.Monad.Logger
@@ -16,7 +17,7 @@ import           Control.Monad.Trans.Resource
 dumpSubscription
   :: (MonadLogger m, MonadNakadi IO m, MonadUnliftIO m, MonadMask m)
   => Nakadi.SubscriptionId
-  -> m ()
+  -> m Void
 dumpSubscription subscriptionId = runResourceT
   $ Nakadi.subscriptionProcess subscriptionId processBatch
  where


### PR DESCRIPTION
Our Nakadi instance experienced a data loss and thus started reporting
negative unconsumed event counts.
When a consumption is started in this state Nakadi will return a 200
with an empty body.

Currently this simply terminated the conduit @linesUnboundedAsciiC@.
 With this change this will throw a @ConsumptionStoppedException@.

I change the return type to Void to signal that the consumption function
should never terminate (in our codebase people simply wrapped it in an
infinite loop).
The Nakadi docs (https://nakadi.io/manual.html#consuming-events-from-a-subscription)
only talk about an "info" field returned in batches,
which can "potentialy contain the reason Nakadi closed the connection".
No more information about Nakadi-initiated closing of connections is
provided.