### PR TITLE
Add cabal file to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ cabal.sandbox.config
 .stack-work/
 cabal.project.local
 TAGS
-nakadi-client.cabal
 .idea
 out
 *.iml

--- a/nakadi-client.cabal
+++ b/nakadi-client.cabal
@@ -1,0 +1,231 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 3ec0566f946f77d1552db269b4d78bac3832e35fbb1e0e46003d5410086516d9
+
+name:           nakadi-client
+version:        0.7.0.0
+synopsis:       Client library for the Nakadi Event Broker
+description:    This package implements a client library for interacting with the Nakadi event broker system developed by Zalando.
+category:       Network
+homepage:       http://nakadi-client.haskell.silverratio.net
+bug-reports:    https://github.com/mtesseract/nakadi-haskell/issues
+author:         Moritz Clasmeier
+maintainer:     mtesseract@silverratio.net
+copyright:      (c) 2017, 2018, 2019 Moritz Clasmeier
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    AUTHORS.md
+    CHANGES.md
+    .gitignore
+
+source-repository head
+  type: git
+  location: https://github.com/mtesseract/nakadi-haskell
+
+flag devel
+  manual: True
+  default: False
+
+library
+  exposed-modules:
+      Network.Nakadi
+      Network.Nakadi.Prelude
+      Network.Nakadi.Base
+      Network.Nakadi.Config
+      Network.Nakadi.EventTypes
+      Network.Nakadi.EventTypes.CursorDistances
+      Network.Nakadi.EventTypes.CursorsLag
+      Network.Nakadi.EventTypes.Events
+      Network.Nakadi.EventTypes.EventType
+      Network.Nakadi.EventTypes.Partitions
+      Network.Nakadi.EventTypes.Schemas
+      Network.Nakadi.EventTypes.ShiftedCursors
+      Network.Nakadi.Subscriptions
+      Network.Nakadi.Subscriptions.Cursors
+      Network.Nakadi.Subscriptions.Events
+      Network.Nakadi.Subscriptions.Stats
+      Network.Nakadi.Subscriptions.Subscription
+      Network.Nakadi.Types
+      Network.Nakadi.Types.Config
+      Network.Nakadi.Types.Exceptions
+      Network.Nakadi.Types.Logger
+      Network.Nakadi.Types.Problem
+      Network.Nakadi.Types.Service
+      Network.Nakadi.Registry
+      Network.Nakadi.Lenses
+      Network.Nakadi.Internal.Http
+      Network.Nakadi.Internal.Retry
+      Network.Nakadi.HttpBackendIO
+      Network.Nakadi.Unsafe.IO
+  other-modules:
+      Network.Nakadi.Internal.Base
+      Network.Nakadi.Internal.Committer
+      Network.Nakadi.Internal.Committer.NoBuffer
+      Network.Nakadi.Internal.Committer.Shared
+      Network.Nakadi.Internal.Committer.SmartBuffer
+      Network.Nakadi.Internal.Committer.TimeBuffer
+      Network.Nakadi.Internal.Config
+      Network.Nakadi.Internal.Conversions
+      Network.Nakadi.Internal.GlobalConfig
+      Network.Nakadi.Internal.HttpBackendIO
+      Network.Nakadi.Internal.Json
+      Network.Nakadi.Internal.Lenses
+      Network.Nakadi.Internal.Prelude
+      Network.Nakadi.Internal.TH
+      Network.Nakadi.Internal.Types
+      Network.Nakadi.Internal.Types.Base
+      Network.Nakadi.Internal.Types.Committer
+      Network.Nakadi.Internal.Types.Config
+      Network.Nakadi.Internal.Types.Exceptions
+      Network.Nakadi.Internal.Types.Logger
+      Network.Nakadi.Internal.Types.Problem
+      Network.Nakadi.Internal.Types.Service
+      Network.Nakadi.Internal.Types.Subscriptions
+      Network.Nakadi.Internal.Types.Util
+      Network.Nakadi.Internal.Types.Worker
+      Network.Nakadi.Internal.Unsafe.IO
+      Network.Nakadi.Internal.Util
+      Network.Nakadi.Internal.Worker
+      Network.Nakadi.Types.Subscriptions
+      Paths_nakadi_client
+  hs-source-dirs:
+      src
+  default-extensions: NoImplicitPrelude OverloadedStrings DuplicateRecordFields
+  build-depends:
+      aeson
+    , aeson-casing
+    , async >=2.2.1 && <2.3.0
+    , async-timer >=0.2.0.0 && <0.3
+    , base >=4.7 && <5
+    , bytestring
+    , conduit >=1.3.0 && <1.4.0
+    , conduit-extra >=1.3.0 && <1.4.0
+    , containers
+    , exceptions
+    , hashable
+    , http-client
+    , http-client-tls
+    , http-conduit >=2.3.0 && <2.4
+    , http-types
+    , iso8601-time
+    , lens
+    , modern-uri >=0.2.1.0 && <0.4
+    , monad-control
+    , monad-logger
+    , mtl
+    , resourcet >=1.2.0 && <1.3
+    , retry
+    , safe-exceptions >=0.1.7.0 && <0.2
+    , scientific
+    , split
+    , stm
+    , stm-chans
+    , template-haskell
+    , text
+    , time
+    , transformers
+    , transformers-base
+    , unliftio >=0.2.4.0 && <0.3
+    , unliftio-core
+    , unordered-containers
+    , uuid
+    , vector
+  if flag(devel)
+    ghc-options: -Wall -fno-warn-type-defaults -Werror
+  else
+    ghc-options: -Wall -fno-warn-type-defaults
+  default-language: Haskell2010
+
+test-suite nakadi-client-test-suite
+  type: exitcode-stdio-1.0
+  main-is: Tests.hs
+  other-modules:
+      Network.Nakadi.Config.Test
+      Network.Nakadi.Connection.Test
+      Network.Nakadi.EventTypes.BusinessEvents.Test
+      Network.Nakadi.EventTypes.CursorsLag.Test
+      Network.Nakadi.EventTypes.ShiftedCursors.Test
+      Network.Nakadi.EventTypes.Test
+      Network.Nakadi.Examples.ListEventTypes.Test
+      Network.Nakadi.Examples.Subscription.Process
+      Network.Nakadi.Examples.Subscription.Test
+      Network.Nakadi.Examples.Test
+      Network.Nakadi.Internal.Http.Test
+      Network.Nakadi.Internal.Retry.Test
+      Network.Nakadi.Internal.Test
+      Network.Nakadi.Internal.Types.Problem.Test
+      Network.Nakadi.Internal.Types.Test
+      Network.Nakadi.MonadicAPI.Test
+      Network.Nakadi.Registry.Test
+      Network.Nakadi.Subscriptions.Processing.Test
+      Network.Nakadi.Subscriptions.Stats.Test
+      Network.Nakadi.Subscriptions.Test
+      Network.Nakadi.Tests.Common
+      Paths_nakadi_client
+  hs-source-dirs:
+      tests
+  default-extensions: NoImplicitPrelude OverloadedStrings DuplicateRecordFields
+  ghc-options: -Wall -fno-warn-type-defaults
+  build-depends:
+      aeson
+    , aeson-casing
+    , aeson-qq >=0.8.2 && <0.9
+    , async
+    , async-timer >=0.2.0.0 && <0.3
+    , base >=4.7 && <5
+    , bytestring
+    , classy-prelude >=1.4.0 && <1.5.0
+    , conduit >=1.3.0 && <1.4.0
+    , conduit-extra >=1.3.0 && <1.4.0
+    , containers
+    , exceptions
+    , fast-logger
+    , hashable
+    , http-client
+    , http-client-tls
+    , http-conduit
+    , http-types
+    , iso8601-time
+    , lens
+    , lens-aeson
+    , modern-uri >=0.2.1.0 && <0.4
+    , monad-control
+    , monad-logger
+    , mtl
+    , nakadi-client
+    , random
+    , resourcet >=1.2.0 && <1.3
+    , retry
+    , safe-exceptions >=0.1.7.0 && <0.2
+    , say
+    , scientific
+    , split
+    , stm
+    , stm-chans
+    , stm-conduit >=4.0.0 && <4.1.0
+    , tasty
+    , tasty-hunit
+    , template-haskell
+    , text
+    , time
+    , transformers
+    , transformers-base
+    , unliftio
+    , unliftio-core
+    , unordered-containers
+    , uuid
+    , vector
+    , wai
+    , warp
+  if flag(devel)
+    ghc-options: -Wall -fno-warn-type-defaults -Werror
+  else
+    ghc-options: -Wall -fno-warn-type-defaults
+  default-language: Haskell2010


### PR DESCRIPTION
While building our project with stack we get:

```
Cloning 53676f4027c0fb6d27f91cac99d1bd99d2b9dfbc from https://github.com/mtesseract/nakadi-client.git
DEPRECATED: The package at Repo from https://github.com/mtesseract/nakadi-client.git, commit 53676f4027c0fb6d27f91cac99d1bd99d2b9dfbc does not include a cabal file.
Instead, it includes an hpack package.yaml file for generating a cabal file.
This usage is deprecated; please see https://github.com/commercialhaskell/stack/issues/5210.
Support for this workflow will be removed in the future.
```